### PR TITLE
[dev] Cache static Encoding in BlobString/BlobNullTerminatedString

### DIFF
--- a/src/Paradise.BLOB/Blob/BlobNullTerminatedString.cs
+++ b/src/Paradise.BLOB/Blob/BlobNullTerminatedString.cs
@@ -4,10 +4,12 @@ namespace Paradise.BLOB;
 
 public unsafe struct BlobNullTerminatedString<TEncoding> where TEncoding : Encoding, new()
 {
+    private static readonly TEncoding s_encoding = new TEncoding();
+
     internal BlobArray<byte> Data;
     public int Length => Data.Length - 1/* length without termination */;
     public byte* UnsafePtr => Data.UnsafePtr;
-    public new string ToString() => new TEncoding().GetString(Data.UnsafePtr, Length);
+    public new string ToString() => s_encoding.GetString(Data.UnsafePtr, Length);
 #if UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER
     public System.Span<byte> ToSpan() => new System.Span<byte>(UnsafePtr, Length);
 #endif

--- a/src/Paradise.BLOB/Blob/BlobString.cs
+++ b/src/Paradise.BLOB/Blob/BlobString.cs
@@ -4,10 +4,12 @@ namespace Paradise.BLOB;
 
 public unsafe struct BlobString<TEncoding> where TEncoding : Encoding, new()
 {
+    private static readonly TEncoding s_encoding = new TEncoding();
+
     internal BlobArray<byte> Data;
     public int Length => Data.Length;
     public byte* UnsafePtr => Data.UnsafePtr;
-    public new string ToString() => new TEncoding().GetString(Data.UnsafePtr, Data.Length);
+    public new string ToString() => s_encoding.GetString(Data.UnsafePtr, Data.Length);
 #if UNITY_2021_2_OR_NEWER || NETSTANDARD2_1_OR_GREATER
     public System.Span<byte> ToSpan() => Data.ToSpan();
 #endif


### PR DESCRIPTION
Closes #4

## Summary
- Cache `TEncoding` instance as a `private static readonly` field (`s_encoding`) in both `BlobString<TEncoding>` and `BlobNullTerminatedString<TEncoding>`
- Eliminates unnecessary allocation of a new `Encoding` object on every `ToString()` call
- Since these are generic structs, `s_encoding` is shared per `TEncoding` specialization, which is the desired behavior

## Test plan
- [x] Paradise.BLOB builds with zero warnings (`TreatWarningsAsErrors=true`)
- [x] Paradise.BT builds with zero warnings (both `netstandard2.1` and `net10.0` targets)
- [x] All 484 BLOB tests pass