### PR TITLE
[dev] Fix TickChildrenReturnBreakOrDefault returning 0 for completed children

### DIFF
--- a/src/Paradise.BT.Test/BehaviorTreeTests.cs
+++ b/src/Paradise.BT.Test/BehaviorTreeTests.cs
@@ -147,6 +147,42 @@ public sealed class BehaviorTreeTests
     }
 
     [Test]
+    public async Task Sequence_Returns_Failure_Not_Zero_When_Child_Already_Failed()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        // First tick: Failure child breaks the sequence -> returns Failure
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+
+        // Second tick: child is already completed (Failure), should still return Failure not 0
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task Selector_Returns_Success_Not_Zero_When_Child_Already_Succeeded()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Selector(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        // First tick: Success child breaks the selector -> returns Success
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+
+        // Second tick: child is already completed (Success), should still return Success not 0
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
     public async Task Custom_Reset_Action_Runs_When_Tree_Resets()
     {
         var blackboard = new Blackboard();

--- a/src/Paradise.BT.Test/BehaviorTreeTests.cs
+++ b/src/Paradise.BT.Test/BehaviorTreeTests.cs
@@ -183,6 +183,24 @@ public sealed class BehaviorTreeTests
     }
 
     [Test]
+    public async Task Sequence_Returns_Success_On_Retick_When_All_Children_Already_Succeeded()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        // First tick: both children succeed, sequence returns Success
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+
+        // Second tick: all children already completed (no break triggered), should return Success not 0
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
     public async Task Custom_Reset_Action_Runs_When_Tree_Resets()
     {
         var blackboard = new Blackboard();

--- a/src/Paradise.BT/Nodes/NodeExtensions.cs
+++ b/src/Paradise.BT/Nodes/NodeExtensions.cs
@@ -53,14 +53,15 @@ public static class NodeExtensions
         where TNodeBlob : struct, INodeBlob
         where TBlackboard : struct, IBlackboard
     {
-        NodeState currentState = 0;
+        NodeState lastState = 0;
         int endIndex = blob.GetEndIndex(parentIndex);
         int childIndex = parentIndex + 1;
         while (childIndex < endIndex)
         {
             NodeState previousState = blob.GetState(childIndex);
-            currentState = tickCheck(previousState) ? VirtualMachine.Tick(childIndex, ref blob, ref bb) : 0;
-            if (breakCheck(currentState == 0 ? previousState : currentState))
+            NodeState currentState = tickCheck(previousState) ? VirtualMachine.Tick(childIndex, ref blob, ref bb) : 0;
+            lastState = currentState == 0 ? previousState : currentState;
+            if (breakCheck(lastState))
             {
                 break;
             }
@@ -68,6 +69,6 @@ public static class NodeExtensions
             childIndex = blob.GetEndIndex(childIndex);
         }
 
-        return currentState;
+        return lastState;
     }
 }


### PR DESCRIPTION
Closes #11

## Summary
- Fix `TickChildrenReturnBreakOrDefault` to compute effective state (`currentState` or `previousState` for skipped children) once and use it for both the break check and return value
- Previously, when a child was already completed (skipped), `currentState` was set to `0` and that `0` was returned instead of the child's actual `previousState`
- Affects `SequenceNode` and `SelectorNode` when re-ticked after completion with `AutoResetOnCompletion = false`

## Test plan
- [x] Added `Sequence_Returns_Failure_Not_Zero_When_Child_Already_Failed` test
- [x] Added `Selector_Returns_Success_Not_Zero_When_Child_Already_Succeeded` test
- [x] All 14 tests pass
- [x] Build passes with warnings-as-errors