### PR TITLE
[dev] Fix ParallelNode returning invalid NodeState 0 for completed children

### DIFF
--- a/src/Paradise.BT.Test/BehaviorTreeTests.cs
+++ b/src/Paradise.BT.Test/BehaviorTreeTests.cs
@@ -174,6 +174,24 @@ public sealed class BehaviorTreeTests
     }
 
     [Test]
+    public async Task Parallel_Preserves_Failed_Child_State_Alongside_Running_Child()
+    {
+        // Child 1: instant Failure. Child 2: Running on tick 1, Success on tick 2.
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Parallel(
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Node(new CountingNode())));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        // Tick 1: child1 Failure + child2 Running → Running (Running takes priority)
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+
+        // Tick 2: child1 already completed (Failure preserved), child2 completes (Success) → Failure
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
     public async Task Custom_Struct_Node_Can_Be_Authored_Through_Interface_Constraints()
     {
         var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Node(new CountingNode()));

--- a/src/Paradise.BT.Test/BehaviorTreeTests.cs
+++ b/src/Paradise.BT.Test/BehaviorTreeTests.cs
@@ -137,6 +137,43 @@ public sealed class BehaviorTreeTests
     }
 
     [Test]
+    public async Task Parallel_Preserves_Completed_Children_State()
+    {
+        // Child 1: instant Success. Child 2: Running on tick 1, Success on tick 2.
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Parallel(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Node(new CountingNode())));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        // Tick 1: child2 returns Running → Parallel returns Running
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+
+        // Tick 2: child1 already completed (Success preserved), child2 now completes → Success
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Parallel_All_Children_Already_Completed_Returns_Valid_State()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Parallel(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        // Tick 1: both children complete → Failure (because one child failed)
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+
+        // Tick 2: all children already completed, no reset → should still return valid state, not 0
+        NodeState secondTick = instance.Tick();
+        await Assert.That(secondTick).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
     public async Task Custom_Struct_Node_Can_Be_Authored_Through_Interface_Constraints()
     {
         var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Node(new CountingNode()));

--- a/src/Paradise.BT/Nodes/Composites/ParallelNode.cs
+++ b/src/Paradise.BT/Nodes/Composites/ParallelNode.cs
@@ -13,13 +13,13 @@ public struct ParallelNode : INodeData
         while (childIndex < endIndex)
         {
             NodeState previousState = blob.GetState(childIndex);
-            flags |= previousState.IsCompleted() ? 0 : VirtualMachine.Tick(childIndex, ref blob, ref bb);
+            flags |= previousState.IsCompleted() ? previousState : VirtualMachine.Tick(childIndex, ref blob, ref bb);
             childIndex = blob.GetEndIndex(childIndex);
         }
 
         if (flags.HasFlagFast(NodeState.Running)) return NodeState.Running;
         if (flags.HasFlagFast(NodeState.Failure)) return NodeState.Failure;
         if (flags.HasFlagFast(NodeState.Success)) return NodeState.Success;
-        return 0;
+        return NodeState.Success;
     }
 }


### PR DESCRIPTION
Closes #9

## Summary
- Fixed `ParallelNode.Tick()` OR-ing `0` into flags for already-completed children instead of preserving their actual state (`previousState`)
- Changed the empty-node fallthrough return from `0` to `NodeState.Success` to match convention that an empty composite succeeds
- Added two tests: `Parallel_Preserves_Completed_Children_State` (multi-tick scenario) and `Parallel_All_Children_Already_Completed_Returns_Valid_State` (re-tick without auto-reset)

## Test plan
- [x] `Parallel_Preserves_Completed_Children_State` — verifies completed child's Success state is preserved across ticks
- [x] `Parallel_All_Children_Already_Completed_Returns_Valid_State` — verifies re-tick with `AutoResetOnCompletion=false` returns valid Failure, not 0
- [x] Existing `Parallel_Returns_Failure_When_Any_Child_Fails_And_None_Are_Running` test still passes
- [x] All 14 BT tests pass