### PR TITLE
[dev] Push Paradise.BT test coverage close to 100%

### DIFF
--- a/src/Paradise.BT.Test/BehaviorTreeSerializationTests.cs
+++ b/src/Paradise.BT.Test/BehaviorTreeSerializationTests.cs
@@ -73,4 +73,234 @@ public sealed class BehaviorTreeSerializationTests
         await Assert.That(exception is NotSupportedException).IsTrue();
         await Assert.That(exception?.Message.Contains(nameof(DelegateActionNode), StringComparison.Ordinal) ?? false).IsTrue();
     }
+
+    // ============================
+    // Byte array serialization
+    // ============================
+
+    [Test]
+    public async Task SerializeToBytes_And_Deserialize_From_Bytes_Round_Trips()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Selector(
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Success()));
+
+        byte[] bytes = tree.SerializeToBytes();
+        BehaviorTree roundTrippedTree = BehaviorTreeBlobSerializer.Deserialize(bytes);
+        BehaviorTreeInstance instance = roundTrippedTree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task SerializeToBytes_Preserves_Node_Count()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Failure()));
+
+        byte[] bytes = tree.SerializeToBytes();
+        BehaviorTree roundTrippedTree = BehaviorTreeBlobSerializer.Deserialize(bytes);
+
+        await Assert.That(roundTrippedTree.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Serialize_From_Definition_Matches_Serialize_From_Tree()
+    {
+        var definition = BehaviorNodes.Sequence(
+            BehaviorNodes.Success(),
+            BehaviorNodes.Success());
+
+        using var fromDefinition = BehaviorTreeBlobSerializer.Serialize(definition);
+        BehaviorTree tree1 = BehaviorTreeBlobSerializer.Deserialize(fromDefinition);
+
+        BehaviorTree compiled = BehaviorTreeBuilder.Build(definition);
+        using var fromTree = BehaviorTreeBlobSerializer.Serialize(compiled);
+        BehaviorTree tree2 = BehaviorTreeBlobSerializer.Deserialize(fromTree);
+
+        await Assert.That(tree1.Count).IsEqualTo(tree2.Count);
+    }
+
+    [Test]
+    public async Task SerializeToBytes_From_Definition_Works()
+    {
+        var definition = BehaviorNodes.Sequence(BehaviorNodes.Success());
+
+        byte[] bytes = BehaviorTreeBlobSerializer.SerializeToBytes(definition);
+        BehaviorTree tree = BehaviorTreeBlobSerializer.Deserialize(bytes);
+
+        await Assert.That(tree.Count).IsEqualTo(2);
+    }
+
+    // ============================
+    // DelegateConditionNode serialization rejection
+    // ============================
+
+    [Test]
+    public async Task Delegate_Condition_Nodes_Are_Rejected_By_Blob_Serialization()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Condition(_ => true));
+
+        Exception? exception = null;
+        IDisposable? serializedTree = null;
+
+        try
+        {
+            serializedTree = tree.Serialize();
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+        finally
+        {
+            serializedTree?.Dispose();
+        }
+
+        await Assert.That(exception is NotSupportedException).IsTrue();
+        await Assert.That(exception?.Message.Contains(nameof(DelegateConditionNode), StringComparison.Ordinal) ?? false).IsTrue();
+    }
+
+    // ============================
+    // Registry
+    // ============================
+
+    [Test]
+    public async Task Registry_Missing_Guid_Throws_On_Deserialize()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Node(new ThresholdNode { RequiredTicks = 1 }));
+        using var serializedTree = tree.Serialize();
+
+        // Create an empty registry (no built-in nodes either)
+        var emptyRegistry = new BehaviorTreeSerializationRegistry(includeBuiltInNodes: false);
+
+        InvalidOperationException? ex = null;
+        try
+        {
+            BehaviorTreeBlobSerializer.Deserialize(serializedTree, emptyRegistry);
+        }
+        catch (InvalidOperationException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+        await Assert.That(ex!.Message.Contains("not registered", StringComparison.Ordinal)).IsTrue();
+    }
+
+    [Test]
+    public async Task Registry_CreateBuiltIn_Contains_All_Standard_Nodes()
+    {
+        // Build a tree using every built-in node type
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Selector(BehaviorNodes.Failure(), BehaviorNodes.Success()),
+                BehaviorNodes.Parallel(BehaviorNodes.Success(), BehaviorNodes.Running()),
+                BehaviorNodes.Repeat(1, BehaviorNodes.Success()),
+                BehaviorNodes.RepeatForever(BehaviorNodes.Failure(), breakStates: NodeState.Failure),
+                BehaviorNodes.Inverter(BehaviorNodes.Success()),
+                BehaviorNodes.Succeeder(BehaviorNodes.Failure()),
+                BehaviorNodes.Delay(0.1f)));
+
+        // Should not throw - all node types are registered by default
+        using var serialized = tree.Serialize();
+        BehaviorTree roundTripped = BehaviorTreeBlobSerializer.Deserialize(serialized);
+
+        await Assert.That(roundTripped.Count).IsEqualTo(tree.Count);
+    }
+
+    [Test]
+    public async Task Registry_Re_Register_Same_Type_Is_Idempotent()
+    {
+        var registry = new BehaviorTreeSerializationRegistry();
+        // Registering the same type again should not throw
+        registry.Register<ThresholdNode>();
+        registry.Register<ThresholdNode>();
+
+        // Verify it works
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Node(new ThresholdNode { RequiredTicks = 1 }));
+        using var serialized = tree.Serialize();
+        BehaviorTree roundTripped = BehaviorTreeBlobSerializer.Deserialize(serialized, registry);
+
+        await Assert.That(roundTripped.Count).IsEqualTo(1);
+    }
+
+    // ============================
+    // Complex tree round-trip
+    // ============================
+
+    [Test]
+    public async Task Complex_Tree_Round_Trip_Preserves_Behavior()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Inverter(BehaviorNodes.Failure()),
+                BehaviorNodes.Repeat(2, BehaviorNodes.Delay(0.1f))));
+
+        using var serialized = tree.Serialize();
+        BehaviorTree roundTripped = BehaviorTreeBlobSerializer.Deserialize(serialized);
+        BehaviorTreeInstance instance = roundTripped.CreateInstance(new Blackboard());
+
+        // Inverter(Failure) -> Success
+        // Repeat(2, Delay(0.1)) -> needs 2 completions of the delay
+        // Tick with 0.05: Inverter succeeds, Delay running -> Sequence running
+        await Assert.That(instance.Tick(0.05f)).IsEqualTo(NodeState.Running);
+        // Tick with 0.1: Delay completes (1st), repeat resets child, re-ticks delay running
+        await Assert.That(instance.Tick(0.1f)).IsEqualTo(NodeState.Running);
+        // Tick with 0.1: Delay completes (2nd), repeat done -> Sequence success
+        await Assert.That(instance.Tick(0.1f)).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Round_Trip_Preserves_Node_Types()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Inverter(BehaviorNodes.Success())));
+
+        using var serialized = tree.Serialize();
+        BehaviorTree roundTripped = BehaviorTreeBlobSerializer.Deserialize(serialized);
+
+        await Assert.That(roundTripped.GetNodeType(0)).IsEqualTo(typeof(SequenceNode));
+        await Assert.That(roundTripped.GetNodeType(1)).IsEqualTo(typeof(InverterNode));
+        await Assert.That(roundTripped.GetNodeType(2)).IsEqualTo(typeof(SuccessNode));
+    }
+
+    [Test]
+    public async Task Round_Trip_Preserves_Behavior_Types()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Selector(
+                BehaviorNodes.Succeeder(BehaviorNodes.Failure())));
+
+        using var serialized = tree.Serialize();
+        BehaviorTree roundTripped = BehaviorTreeBlobSerializer.Deserialize(serialized);
+
+        await Assert.That(roundTripped.GetNodeBehaviorType(0)).IsEqualTo(BehaviorNodeType.Composite);
+        await Assert.That(roundTripped.GetNodeBehaviorType(1)).IsEqualTo(BehaviorNodeType.Decorate);
+        await Assert.That(roundTripped.GetNodeBehaviorType(2)).IsEqualTo(BehaviorNodeType.Action);
+    }
+
+    [Test]
+    public async Task Custom_Node_Default_Data_Preserved_Through_Round_Trip()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Node(new ThresholdNode { RequiredTicks = 5 }));
+
+        using var serialized = tree.Serialize();
+        var registry = new BehaviorTreeSerializationRegistry().Register<ThresholdNode>();
+        BehaviorTree roundTripped = BehaviorTreeBlobSerializer.Deserialize(serialized, registry);
+        BehaviorTreeInstance instance = roundTripped.CreateInstance(new Blackboard());
+
+        // Needs 5 ticks to complete
+        for (int i = 0; i < 4; i++)
+        {
+            await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        }
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
 }

--- a/src/Paradise.BT.Test/BlackboardTests.cs
+++ b/src/Paradise.BT.Test/BlackboardTests.cs
@@ -2,6 +2,30 @@ namespace Paradise.BT.Test;
 
 public sealed class BlackboardTests
 {
+    private struct TestData
+    {
+        public int Value;
+    }
+
+    private struct OtherData
+    {
+        public float X;
+    }
+
+    private sealed class TestService
+    {
+        public string Name { get; set; } = "";
+    }
+
+    private sealed class OtherService
+    {
+        public int Id { get; set; }
+    }
+
+    // ============================
+    // Named values
+    // ============================
+
     [Test]
     public async Task Named_And_Typed_Values_Can_Be_Read_Back()
     {
@@ -25,5 +49,483 @@ public sealed class BlackboardTests
 
         await Assert.That(found).IsFalse();
         await Assert.That(value).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TryGet_Returns_True_For_Existing_Value()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("health", 100);
+
+        bool found = blackboard.TryGet("health", out int value);
+
+        await Assert.That(found).IsTrue();
+        await Assert.That(value).IsEqualTo(100);
+    }
+
+    [Test]
+    public async Task Has_Returns_False_For_Missing_Key()
+    {
+        var blackboard = new Blackboard();
+
+        await Assert.That(blackboard.Has("nonexistent")).IsFalse();
+    }
+
+    [Test]
+    public async Task Remove_Named_Value_Returns_True_And_Removes()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("key", 42);
+
+        bool removed = blackboard.Remove("key");
+
+        await Assert.That(removed).IsTrue();
+        await Assert.That(blackboard.Has("key")).IsFalse();
+    }
+
+    [Test]
+    public async Task Remove_Missing_Named_Value_Returns_False()
+    {
+        var blackboard = new Blackboard();
+
+        bool removed = blackboard.Remove("nonexistent");
+
+        await Assert.That(removed).IsFalse();
+    }
+
+    [Test]
+    public async Task Get_Missing_Named_Value_Throws_KeyNotFoundException()
+    {
+        var blackboard = new Blackboard();
+
+        KeyNotFoundException? ex = null;
+        try
+        {
+            blackboard.Get<int>("missing");
+        }
+        catch (KeyNotFoundException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task Named_Value_Overwrite_Updates_Value()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("score", 10);
+        blackboard.Set("score", 20);
+
+        await Assert.That(blackboard.Get<int>("score")).IsEqualTo(20);
+    }
+
+    [Test]
+    public async Task Named_Value_Can_Store_Null()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set<string?>("key", null);
+
+        await Assert.That(blackboard.Has("key")).IsTrue();
+
+        bool found = blackboard.TryGet<string?>("key", out string? value);
+        await Assert.That(found).IsTrue();
+        await Assert.That(value).IsNull();
+    }
+
+    [Test]
+    public async Task Get_Named_Value_With_Wrong_Type_Throws_InvalidCastException()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("key", 42);
+
+        InvalidCastException? ex = null;
+        try
+        {
+            blackboard.Get<string>("key");
+        }
+        catch (InvalidCastException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task TryGet_With_Wrong_Type_Returns_False()
+    {
+        var blackboard = new Blackboard();
+        blackboard.Set("key", 42);
+
+        bool found = blackboard.TryGet("key", out string? value);
+
+        await Assert.That(found).IsFalse();
+        await Assert.That(value).IsNull();
+    }
+
+    // ============================
+    // Typed struct data
+    // ============================
+
+    [Test]
+    public async Task SetData_And_GetData_Round_Trips()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetData(new TestData { Value = 99 });
+
+        await Assert.That(blackboard.GetData<TestData>().Value).IsEqualTo(99);
+    }
+
+    [Test]
+    public async Task HasData_Generic_Returns_True_After_Set()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetData(new TestData { Value = 1 });
+
+        await Assert.That(blackboard.HasData<TestData>()).IsTrue();
+    }
+
+    [Test]
+    public async Task HasData_Generic_Returns_False_Before_Set()
+    {
+        var blackboard = new Blackboard();
+
+        await Assert.That(blackboard.HasData<TestData>()).IsFalse();
+    }
+
+    [Test]
+    public async Task HasData_ByType_Returns_True_After_Set()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetData(new TestData());
+
+        await Assert.That(blackboard.HasData(typeof(TestData))).IsTrue();
+    }
+
+    [Test]
+    public async Task HasData_ByType_Returns_False_Before_Set()
+    {
+        var blackboard = new Blackboard();
+
+        await Assert.That(blackboard.HasData(typeof(TestData))).IsFalse();
+    }
+
+    [Test]
+    public async Task GetDataRef_Mutations_Persist()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetData(new TestData { Value = 10 });
+
+        ref TestData dataRef = ref blackboard.GetDataRef<TestData>();
+        dataRef.Value = 42;
+
+        await Assert.That(blackboard.GetData<TestData>().Value).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task SetData_Overwrites_Existing_Value()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetData(new TestData { Value = 1 });
+        blackboard.SetData(new TestData { Value = 2 });
+
+        await Assert.That(blackboard.GetData<TestData>().Value).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RemoveData_Returns_True_And_Removes()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetData(new TestData { Value = 1 });
+
+        bool removed = blackboard.RemoveData<TestData>();
+
+        await Assert.That(removed).IsTrue();
+        await Assert.That(blackboard.HasData<TestData>()).IsFalse();
+    }
+
+    [Test]
+    public async Task RemoveData_Missing_Returns_False()
+    {
+        var blackboard = new Blackboard();
+
+        bool removed = blackboard.RemoveData<TestData>();
+
+        await Assert.That(removed).IsFalse();
+    }
+
+    [Test]
+    public async Task GetData_Missing_Throws_KeyNotFoundException()
+    {
+        var blackboard = new Blackboard();
+
+        KeyNotFoundException? ex = null;
+        try
+        {
+            blackboard.GetData<TestData>();
+        }
+        catch (KeyNotFoundException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task Multiple_Typed_Data_Types_Coexist()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetData(new TestData { Value = 1 });
+        blackboard.SetData(new OtherData { X = 3.14f });
+
+        await Assert.That(blackboard.GetData<TestData>().Value).IsEqualTo(1);
+        await Assert.That(blackboard.GetData<OtherData>().X).IsEqualTo(3.14f);
+    }
+
+    // ============================
+    // Object data
+    // ============================
+
+    [Test]
+    public async Task SetObject_And_GetObject_Round_Trips()
+    {
+        var blackboard = new Blackboard();
+        var service = new TestService { Name = "Renderer" };
+        blackboard.SetObject(service);
+
+        await Assert.That(blackboard.GetObject<TestService>().Name).IsEqualTo("Renderer");
+    }
+
+    [Test]
+    public async Task SetObject_Overwrites_Existing_Object()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetObject(new TestService { Name = "Old" });
+        blackboard.SetObject(new TestService { Name = "New" });
+
+        await Assert.That(blackboard.GetObject<TestService>().Name).IsEqualTo("New");
+    }
+
+    [Test]
+    public async Task RemoveObject_Returns_True_And_Removes()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetObject(new TestService());
+
+        bool removed = blackboard.RemoveObject<TestService>();
+
+        await Assert.That(removed).IsTrue();
+    }
+
+    [Test]
+    public async Task RemoveObject_Missing_Returns_False()
+    {
+        var blackboard = new Blackboard();
+
+        bool removed = blackboard.RemoveObject<TestService>();
+
+        await Assert.That(removed).IsFalse();
+    }
+
+    [Test]
+    public async Task GetObject_Missing_Throws_KeyNotFoundException()
+    {
+        var blackboard = new Blackboard();
+
+        KeyNotFoundException? ex = null;
+        try
+        {
+            blackboard.GetObject<TestService>();
+        }
+        catch (KeyNotFoundException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task Multiple_Object_Types_Coexist()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetObject(new TestService { Name = "A" });
+        blackboard.SetObject(new OtherService { Id = 5 });
+
+        await Assert.That(blackboard.GetObject<TestService>().Name).IsEqualTo("A");
+        await Assert.That(blackboard.GetObject<OtherService>().Id).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task SetObject_Null_Throws_ArgumentNullException()
+    {
+        var blackboard = new Blackboard();
+
+        ArgumentNullException? ex = null;
+        try
+        {
+            blackboard.SetObject<TestService>(null!);
+        }
+        catch (ArgumentNullException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    // ============================
+    // Pointer-based access (unsupported)
+    // ============================
+
+    [Test]
+    public async Task GetDataPtrRO_Throws_NotSupportedException()
+    {
+        var blackboard = new Blackboard();
+
+        NotSupportedException? ex = null;
+        try
+        {
+            blackboard.GetDataPtrRO(typeof(TestData));
+        }
+        catch (NotSupportedException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task GetDataPtrRW_Throws_NotSupportedException()
+    {
+        var blackboard = new Blackboard();
+
+        NotSupportedException? ex = null;
+        try
+        {
+            blackboard.GetDataPtrRW(typeof(TestData));
+        }
+        catch (NotSupportedException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    // ============================
+    // Null argument validation
+    // ============================
+
+    [Test]
+    public async Task HasData_ByType_Null_Throws_ArgumentNullException()
+    {
+        var blackboard = new Blackboard();
+
+        ArgumentNullException? ex = null;
+        try
+        {
+            blackboard.HasData(null!);
+        }
+        catch (ArgumentNullException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task Has_Null_Key_Throws_ArgumentNullException()
+    {
+        var blackboard = new Blackboard();
+
+        ArgumentNullException? ex = null;
+        try
+        {
+            blackboard.Has(null!);
+        }
+        catch (ArgumentNullException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task Get_Null_Key_Throws_ArgumentNullException()
+    {
+        var blackboard = new Blackboard();
+
+        ArgumentNullException? ex = null;
+        try
+        {
+            blackboard.Get<int>(null!);
+        }
+        catch (ArgumentNullException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task Set_Null_Key_Throws_ArgumentNullException()
+    {
+        var blackboard = new Blackboard();
+
+        ArgumentNullException? ex = null;
+        try
+        {
+            blackboard.Set(null!, 42);
+        }
+        catch (ArgumentNullException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task TryGet_Null_Key_Throws_ArgumentNullException()
+    {
+        var blackboard = new Blackboard();
+
+        ArgumentNullException? ex = null;
+        try
+        {
+            blackboard.TryGet(null!, out int _);
+        }
+        catch (ArgumentNullException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task Remove_Null_Key_Throws_ArgumentNullException()
+    {
+        var blackboard = new Blackboard();
+
+        ArgumentNullException? ex = null;
+        try
+        {
+            blackboard.Remove(null!);
+        }
+        catch (ArgumentNullException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
     }
 }

--- a/src/Paradise.BT.Test/CoreTests.cs
+++ b/src/Paradise.BT.Test/CoreTests.cs
@@ -1,0 +1,394 @@
+namespace Paradise.BT.Test;
+
+public sealed class CoreTests
+{
+    // ============================
+    // BehaviorTreeBuilder validation
+    // ============================
+
+    [Test]
+    public async Task Builder_Rejects_Action_Node_With_Children()
+    {
+        InvalidOperationException? ex = null;
+        try
+        {
+            BehaviorTreeBuilder.Build(
+                BehaviorNodes.Node(new SuccessNode(), BehaviorNodeType.Action, BehaviorNodes.Success()));
+        }
+        catch (InvalidOperationException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+        await Assert.That(ex!.Message.Contains("Action", StringComparison.Ordinal)).IsTrue();
+    }
+
+    [Test]
+    public async Task Builder_Rejects_Decorator_With_Zero_Children()
+    {
+        InvalidOperationException? ex = null;
+        try
+        {
+            BehaviorTreeBuilder.Build(
+                BehaviorNodes.Node(new InverterNode(), BehaviorNodeType.Decorate));
+        }
+        catch (InvalidOperationException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+        await Assert.That(ex!.Message.Contains("Decorator", StringComparison.Ordinal)).IsTrue();
+    }
+
+    [Test]
+    public async Task Builder_Rejects_Decorator_With_Two_Children()
+    {
+        InvalidOperationException? ex = null;
+        try
+        {
+            BehaviorTreeBuilder.Build(
+                BehaviorNodes.Node(new InverterNode(), BehaviorNodeType.Decorate,
+                    BehaviorNodes.Success(),
+                    BehaviorNodes.Failure()));
+        }
+        catch (InvalidOperationException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+        await Assert.That(ex!.Message.Contains("Decorator", StringComparison.Ordinal)).IsTrue();
+    }
+
+    [Test]
+    public async Task Builder_Accepts_Composite_With_Any_Number_Of_Children()
+    {
+        // Composite with 0 children should also be valid (no constraint)
+        BehaviorTree tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Node(new SequenceNode(), BehaviorNodeType.Composite));
+
+        await Assert.That(tree.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Builder_Validates_Nested_Nodes()
+    {
+        // Invalid nested decorator (0 children) inside a valid sequence
+        InvalidOperationException? ex = null;
+        try
+        {
+            BehaviorTreeBuilder.Build(
+                BehaviorNodes.Sequence(
+                    BehaviorNodes.Node(new InverterNode(), BehaviorNodeType.Decorate)));
+        }
+        catch (InvalidOperationException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task Builder_Instance_Method_Produces_Same_Result()
+    {
+        var definition = BehaviorNodes.Sequence(
+            BehaviorNodes.Success(),
+            BehaviorNodes.Failure());
+
+        BehaviorTree tree = new BehaviorTreeBuilder(definition).Build();
+
+        await Assert.That(tree.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Builder_Null_Root_Throws_ArgumentNullException()
+    {
+        ArgumentNullException? ex = null;
+        try
+        {
+            _ = new BehaviorTreeBuilder(null!);
+        }
+        catch (ArgumentNullException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    // ============================
+    // BehaviorTree public API
+    // ============================
+
+    [Test]
+    public async Task BehaviorTree_Count_Matches_Total_Node_Count()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Inverter(BehaviorNodes.Failure())));
+
+        // Sequence(1) + Success(1) + Inverter(1) + Failure(1) = 4
+        await Assert.That(tree.Count).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task BehaviorTree_GetNodeType_Returns_Correct_Types()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Success()));
+
+        await Assert.That(tree.GetNodeType(0)).IsEqualTo(typeof(SequenceNode));
+        await Assert.That(tree.GetNodeType(1)).IsEqualTo(typeof(SuccessNode));
+    }
+
+    [Test]
+    public async Task BehaviorTree_GetNodeBehaviorType_Returns_Correct_Kinds()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Inverter(BehaviorNodes.Success())));
+
+        await Assert.That(tree.GetNodeBehaviorType(0)).IsEqualTo(BehaviorNodeType.Composite);
+        await Assert.That(tree.GetNodeBehaviorType(1)).IsEqualTo(BehaviorNodeType.Decorate);
+        await Assert.That(tree.GetNodeBehaviorType(2)).IsEqualTo(BehaviorNodeType.Action);
+    }
+
+    [Test]
+    public async Task BehaviorTree_GetEndIndex_Returns_Correct_Indices()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Failure()));
+
+        // Sequence at 0 ends at 3 (total count)
+        await Assert.That(tree.GetEndIndex(0)).IsEqualTo(3);
+        // Success at 1 ends at 2
+        await Assert.That(tree.GetEndIndex(1)).IsEqualTo(2);
+        // Failure at 2 ends at 3
+        await Assert.That(tree.GetEndIndex(2)).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task BehaviorTree_GetNodeType_Out_Of_Range_Throws()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(BehaviorNodes.Success());
+
+        ArgumentOutOfRangeException? ex = null;
+        try
+        {
+            tree.GetNodeType(5);
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    [Test]
+    public async Task BehaviorTree_GetNodeType_Negative_Index_Throws()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(BehaviorNodes.Success());
+
+        ArgumentOutOfRangeException? ex = null;
+        try
+        {
+            tree.GetNodeType(-1);
+        }
+        catch (ArgumentOutOfRangeException e)
+        {
+            ex = e;
+        }
+
+        await Assert.That(ex).IsNotNull();
+    }
+
+    // ============================
+    // BehaviorTreeInstance lifecycle
+    // ============================
+
+    [Test]
+    public async Task Instance_Status_Reflects_Last_Tick_Result()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Success());
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        instance.Tick();
+
+        await Assert.That(instance.Status).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Instance_AutoReset_Disabled_Does_Not_Reset_On_Completion()
+    {
+        int executions = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Action(_ =>
+            {
+                executions++;
+                return NodeState.Success;
+            }));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        instance.Tick();
+        instance.Tick();
+
+        // Without auto-reset, the second tick sees the completed state and should
+        // still return Success (the node is not re-executed)
+        await Assert.That(instance.Status).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Instance_AutoReset_Enabled_Resets_And_Reticks()
+    {
+        int executions = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Action(_ =>
+            {
+                executions++;
+                return NodeState.Success;
+            }));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        instance.Tick();
+        instance.Tick();
+
+        await Assert.That(executions).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Instance_Reset_Clears_State_To_Running()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Running());
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        instance.Tick();
+        await Assert.That(instance.Status).IsEqualTo(NodeState.Running);
+
+        instance.Reset();
+        // After reset, state is cleared to 0 (no flags set)
+        await Assert.That(instance.Status).IsEqualTo((NodeState)0);
+    }
+
+    [Test]
+    public async Task Instance_Tick_Sets_DeltaTime_On_Blackboard()
+    {
+        float capturedDeltaTime = 0f;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Action(bb =>
+            {
+                capturedDeltaTime = bb.GetData<BehaviorTreeTickDeltaTime>().Value;
+                return NodeState.Success;
+            }));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.Tick(0.016f);
+
+        await Assert.That(capturedDeltaTime).IsEqualTo(0.016f);
+    }
+
+    [Test]
+    public async Task Instance_CreateInstance_Without_Blackboard_Works()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Success());
+        BehaviorTreeInstance instance = tree.CreateInstance();
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Instance_Blackboard_Ref_Is_Accessible()
+    {
+        var blackboard = new Blackboard();
+        blackboard.SetData(42);
+
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Success());
+        BehaviorTreeInstance instance = tree.CreateInstance(blackboard);
+
+        await Assert.That(instance.Blackboard.GetData<int>()).IsEqualTo(42);
+    }
+
+    // ============================
+    // Complex tree scenarios
+    // ============================
+
+    [Test]
+    public async Task Deep_Nested_Tree_Executes_Correctly()
+    {
+        // Sequence -> Inverter -> Failure = Sequence(Inverter(Failure))
+        // Inverter turns Failure into Success, Sequence with one child returns that
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Inverter(BehaviorNodes.Failure()),
+                BehaviorNodes.Succeeder(BehaviorNodes.Failure())));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        // Both children return Success -> Sequence returns Success
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Selector_With_Running_Then_Success_Returns_Running_First()
+    {
+        int tickCount = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Selector(
+                BehaviorNodes.Action(_ =>
+                {
+                    tickCount++;
+                    return tickCount == 1 ? NodeState.Running : NodeState.Failure;
+                }),
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        // First tick: first child is Running -> Selector returns Running
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        // Second tick: first child fails, second child succeeds -> Success
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    // ============================
+    // BehaviorNodes factory inference
+    // ============================
+
+    [Test]
+    public async Task BehaviorNodes_Node_Infers_Action_Type_With_No_Children()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Node(new SuccessNode()));
+
+        await Assert.That(tree.GetNodeBehaviorType(0)).IsEqualTo(BehaviorNodeType.Action);
+    }
+
+    [Test]
+    public async Task BehaviorNodes_Node_Infers_Decorate_Type_With_One_Child()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Node(new InverterNode(), BehaviorNodes.Success()));
+
+        await Assert.That(tree.GetNodeBehaviorType(0)).IsEqualTo(BehaviorNodeType.Decorate);
+    }
+
+    [Test]
+    public async Task BehaviorNodes_Node_Infers_Composite_Type_With_Multiple_Children()
+    {
+        BehaviorTree tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Node(new SequenceNode(), BehaviorNodes.Success(), BehaviorNodes.Success()));
+
+        await Assert.That(tree.GetNodeBehaviorType(0)).IsEqualTo(BehaviorNodeType.Composite);
+    }
+}

--- a/src/Paradise.BT.Test/NodeTests.cs
+++ b/src/Paradise.BT.Test/NodeTests.cs
@@ -1,0 +1,633 @@
+namespace Paradise.BT.Test;
+
+public sealed class NodeTests
+{
+    // ============================
+    // SequenceNode
+    // ============================
+
+    [Test]
+    public async Task Sequence_All_Children_Succeed_Returns_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Success(),
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Sequence_First_Child_Fails_Returns_Failure_Without_Ticking_Rest()
+    {
+        int secondChildTicked = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Action(_ =>
+                {
+                    secondChildTicked++;
+                    return NodeState.Success;
+                })));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+        await Assert.That(secondChildTicked).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Sequence_Running_Child_Resumes_On_Next_Tick()
+    {
+        int tickCount = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Action(_ =>
+                {
+                    tickCount++;
+                    return tickCount >= 2 ? NodeState.Success : NodeState.Running;
+                }),
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Sequence_Resumes_From_Running_Child_Skipping_Completed_Siblings()
+    {
+        int firstChildTicks = 0;
+        int secondChildTicks = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Sequence(
+                BehaviorNodes.Action(_ =>
+                {
+                    firstChildTicks++;
+                    return NodeState.Success;
+                }),
+                BehaviorNodes.Action(_ =>
+                {
+                    secondChildTicks++;
+                    return secondChildTicks >= 2 ? NodeState.Success : NodeState.Running;
+                })));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        // Tick 1: first child succeeds, second child returns running
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(firstChildTicks).IsEqualTo(1);
+        await Assert.That(secondChildTicks).IsEqualTo(1);
+
+        // Tick 2: first child already completed (not re-ticked), second child now succeeds
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+        await Assert.That(firstChildTicks).IsEqualTo(1);
+        await Assert.That(secondChildTicks).IsEqualTo(2);
+    }
+
+    // ============================
+    // SelectorNode
+    // ============================
+
+    [Test]
+    public async Task Selector_All_Children_Fail_Returns_Failure()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Selector(
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task Selector_First_Child_Succeeds_Stops_Immediately()
+    {
+        int secondChildTicked = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Selector(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Action(_ =>
+                {
+                    secondChildTicked++;
+                    return NodeState.Failure;
+                })));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+        await Assert.That(secondChildTicked).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Selector_Running_Child_Resumes_On_Next_Tick()
+    {
+        int tickCount = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Selector(
+                BehaviorNodes.Action(_ =>
+                {
+                    tickCount++;
+                    return tickCount >= 2 ? NodeState.Success : NodeState.Running;
+                }),
+                BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Selector_Skips_Failed_Children_And_Tries_Next()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Selector(
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    // ============================
+    // ParallelNode
+    // ============================
+
+    [Test]
+    public async Task Parallel_All_Children_Succeed_Returns_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Parallel(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Success(),
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Parallel_All_Children_Fail_Returns_Failure()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Parallel(
+                BehaviorNodes.Failure(),
+                BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task Parallel_Running_Takes_Priority_Over_Success_And_Failure()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Parallel(
+                BehaviorNodes.Success(),
+                BehaviorNodes.Running(),
+                BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+    }
+
+    // ============================
+    // RepeatTimesNode
+    // ============================
+
+    [Test]
+    public async Task RepeatTimes_Zero_Repeats_Returns_Success_Immediately()
+    {
+        int executions = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Repeat(
+                0,
+                BehaviorNodes.Action(_ =>
+                {
+                    executions++;
+                    return NodeState.Success;
+                })));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        // With 0 repeats, child is ticked once and TickTimes goes from 0 to -1, returning Success
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task RepeatTimes_BreakStates_Stops_On_Failure()
+    {
+        int executions = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Repeat(
+                5,
+                BehaviorNodes.Action(_ =>
+                {
+                    executions++;
+                    return executions == 2 ? NodeState.Failure : NodeState.Success;
+                }),
+                breakStates: NodeState.Failure));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        // Tick 1: child returns Success, TickTimes 5->4 -> Running
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        // Tick 2: child returns Failure, break -> Failure
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+        await Assert.That(executions).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RepeatTimes_One_Repeat_Succeeds_On_First_Completion()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Repeat(
+                1,
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    // ============================
+    // RepeatForeverNode
+    // ============================
+
+    [Test]
+    public async Task RepeatForever_Keeps_Running_On_Child_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.RepeatForever(
+                BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+    }
+
+    [Test]
+    public async Task RepeatForever_Keeps_Running_On_Child_Failure()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.RepeatForever(
+                BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.AutoResetOnCompletion = false;
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+    }
+
+    [Test]
+    public async Task RepeatForever_BreakStates_Stops_On_Failure()
+    {
+        int executions = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.RepeatForever(
+                BehaviorNodes.Action(_ =>
+                {
+                    executions++;
+                    return executions == 3 ? NodeState.Failure : NodeState.Success;
+                }),
+                breakStates: NodeState.Failure));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task RepeatForever_BreakStates_Stops_On_Success()
+    {
+        int executions = 0;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.RepeatForever(
+                BehaviorNodes.Action(_ =>
+                {
+                    executions++;
+                    return executions == 2 ? NodeState.Success : NodeState.Failure;
+                }),
+                breakStates: NodeState.Success));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    // ============================
+    // InverterNode
+    // ============================
+
+    [Test]
+    public async Task Inverter_Inverts_Success_To_Failure()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Inverter(BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task Inverter_Inverts_Failure_To_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Inverter(BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Inverter_Passes_Through_Running()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Inverter(BehaviorNodes.Running()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+    }
+
+    // ============================
+    // SucceederNode
+    // ============================
+
+    [Test]
+    public async Task Succeeder_Converts_Failure_To_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Succeeder(BehaviorNodes.Failure()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Succeeder_Passes_Through_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Succeeder(BehaviorNodes.Success()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Succeeder_Passes_Through_Running()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Succeeder(BehaviorNodes.Running()));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+    }
+
+    // ============================
+    // DelayTimerNode
+    // ============================
+
+    [Test]
+    public async Task Delay_Zero_Seconds_Succeeds_Immediately()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Delay(0f));
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Delay_Exact_Boundary_Succeeds()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Delay(1.0f));
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick(0.5f)).IsEqualTo(NodeState.Running);
+        await Assert.That(instance.Tick(0.5f)).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task Delay_Overshoot_Still_Succeeds()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Delay(0.3f));
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick(1.0f)).IsEqualTo(NodeState.Success);
+    }
+
+    // ============================
+    // DelegateActionNode
+    // ============================
+
+    [Test]
+    public async Task DelegateAction_Returns_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Action(_ => NodeState.Success));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task DelegateAction_Returns_Failure()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Action(_ => NodeState.Failure));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task DelegateAction_Returns_Running()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Action(_ => NodeState.Running));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+    }
+
+    [Test]
+    public async Task DelegateAction_With_Index_Receives_Correct_Index()
+    {
+        int receivedIndex = -1;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Action((_, index) =>
+            {
+                receivedIndex = index;
+                return NodeState.Success;
+            }));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.Tick();
+
+        // Root node is at index 0
+        await Assert.That(receivedIndex).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DelegateAction_Receives_Blackboard()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Action(bb =>
+            {
+                int value = bb.GetData<int>();
+                return value == 42 ? NodeState.Success : NodeState.Failure;
+            }));
+
+        var blackboard = new Blackboard();
+        blackboard.SetData(42);
+        BehaviorTreeInstance instance = tree.CreateInstance(blackboard);
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    // ============================
+    // DelegateConditionNode
+    // ============================
+
+    [Test]
+    public async Task DelegateCondition_True_Returns_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Condition(_ => true));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task DelegateCondition_False_Returns_Failure()
+    {
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Condition(_ => false));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task DelegateCondition_With_Index_Receives_Correct_Index()
+    {
+        int receivedIndex = -1;
+        var tree = BehaviorTreeBuilder.Build(
+            BehaviorNodes.Condition((_, index) =>
+            {
+                receivedIndex = index;
+                return true;
+            }));
+
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+        instance.Tick();
+
+        await Assert.That(receivedIndex).IsEqualTo(0);
+    }
+
+    // ============================
+    // SuccessNode, FailedNode, RunningNode
+    // ============================
+
+    [Test]
+    public async Task SuccessNode_Always_Returns_Success()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Success());
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Success);
+    }
+
+    [Test]
+    public async Task FailedNode_Always_Returns_Failure()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Failure());
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task RunningNode_Always_Returns_Running()
+    {
+        var tree = BehaviorTreeBuilder.Build(BehaviorNodes.Running());
+        BehaviorTreeInstance instance = tree.CreateInstance(new Blackboard());
+
+        await Assert.That(instance.Tick()).IsEqualTo(NodeState.Running);
+    }
+
+    // ============================
+    // NodeState Extensions
+    // ============================
+
+    [Test]
+    public async Task NodeState_IsCompleted_True_For_Success_And_Failure()
+    {
+        await Assert.That(NodeState.Success.IsCompleted()).IsTrue();
+        await Assert.That(NodeState.Failure.IsCompleted()).IsTrue();
+        await Assert.That(NodeState.Running.IsCompleted()).IsFalse();
+    }
+
+    [Test]
+    public async Task NodeState_HasFlagFast_Works_With_Combined_Flags()
+    {
+        NodeState combined = NodeState.Success | NodeState.Failure;
+        await Assert.That(combined.HasFlagFast(NodeState.Success)).IsTrue();
+        await Assert.That(combined.HasFlagFast(NodeState.Failure)).IsTrue();
+        await Assert.That(combined.HasFlagFast(NodeState.Running)).IsFalse();
+    }
+
+    [Test]
+    public async Task NodeState_ToNodeState_Converts_Bool()
+    {
+        await Assert.That(true.ToNodeState()).IsEqualTo(NodeState.Success);
+        await Assert.That(false.ToNodeState()).IsEqualTo(NodeState.Failure);
+    }
+
+    [Test]
+    public async Task NodeState_IsRunningOrFailure_Returns_Correct_Values()
+    {
+        await Assert.That(NodeState.Running.IsRunningOrFailure()).IsTrue();
+        await Assert.That(NodeState.Failure.IsRunningOrFailure()).IsTrue();
+        await Assert.That(NodeState.Success.IsRunningOrFailure()).IsFalse();
+    }
+
+    [Test]
+    public async Task NodeState_IsRunningOrSuccess_Returns_Correct_Values()
+    {
+        await Assert.That(NodeState.Running.IsRunningOrSuccess()).IsTrue();
+        await Assert.That(NodeState.Success.IsRunningOrSuccess()).IsTrue();
+        await Assert.That(NodeState.Failure.IsRunningOrSuccess()).IsFalse();
+    }
+}


### PR DESCRIPTION
Closes #19

## Summary
- Add **NodeTests.cs**: 43 tests covering all node types (composites, decorators, actions) with edge cases like running child resume, break states, zero repeats, exact boundary timing, delegate index passing, and NodeState extension methods
- Add **CoreTests.cs**: 25 tests covering BehaviorTreeBuilder validation (action/decorator child count), BehaviorTree public API (Count, GetNodeType, GetNodeBehaviorType, GetEndIndex, bounds checking), BehaviorTreeInstance lifecycle (Status, Reset, AutoReset, DeltaTime, Blackboard access), complex nested trees, and BehaviorNodes factory type inference
- Extend **BlackboardTests.cs**: from 2 to 35 tests covering typed struct data (Set/Get/GetDataRef/Remove/HasData), object data (Set/Get/Remove), named values (Set/Get/TryGet/Has/Remove, overwrite, null storage, type mismatch), pointer-based access (NotSupportedException), and null argument validation for all keyed methods
- Extend **BehaviorTreeSerializationTests.cs**: from 3 to 16 tests covering byte array serialization round-trip, DelegateConditionNode rejection, registry edge cases (missing GUID, re-registration idempotency, CreateBuiltIn completeness), complex tree round-trip behavior preservation, and node/behavior type preservation through serialization

Total: **135 tests** (up from 16)

## Test plan
- [x] `dotnet build src/Paradise.BT.Test/Paradise.BT.Test.csproj -p:TreatWarningsAsErrors=true` passes with 0 warnings, 0 errors
- [x] `dotnet test --project src/Paradise.BT.Test/Paradise.BT.Test.csproj -p:PublishAot=false --output normal` passes with 135 tests, 0 failures