### PR TITLE
[dev] Push Paradise.BLOB test coverage close to 100%

### DIFF
--- a/src/Paradise.BLOB.Test/AssertCompat.cs
+++ b/src/Paradise.BLOB.Test/AssertCompat.cs
@@ -5,15 +5,15 @@ namespace Paradise.BLOB.Test;
 
 public static class Assert
 {
-    public static void AreEqual<T>(T expected, T actual, string message = null)
+    public static void AreEqual<T>(T expected, T actual, string? message = null)
     {
-        if (!ConstraintHelpers.AreEqual(expected, actual))
+        if (!ConstraintHelpers.AreEqual(expected!, actual!))
         {
-            Fail(message ?? $"Expected: {ConstraintHelpers.Format(expected)} Actual: {ConstraintHelpers.Format(actual)}");
+            Fail(message ?? $"Expected: {ConstraintHelpers.Format(expected!)} Actual: {ConstraintHelpers.Format(actual!)}");
         }
     }
 
-    public static void IsNotNull(object value, string message = null)
+    public static void IsNotNull(object? value, string? message = null)
     {
         if (value is null)
         {
@@ -21,15 +21,15 @@ public static class Assert
         }
     }
 
-    public static void GreaterOrEqual<T>(T actual, T expected, string message = null) where T : IComparable<T>
+    public static void GreaterOrEqual<T>(T actual, T expected, string? message = null) where T : IComparable<T>
     {
         if (actual.CompareTo(expected) < 0)
         {
-            Fail(message ?? $"Expected {ConstraintHelpers.Format(actual)} to be greater than or equal to {ConstraintHelpers.Format(expected)}.");
+            Fail(message ?? $"Expected {ConstraintHelpers.Format(actual!)} to be greater than or equal to {ConstraintHelpers.Format(expected!)}.");
         }
     }
 
-    public static void That(object actual, IConstraint constraint, string message = null)
+    public static void That(object actual, IConstraint constraint, string? message = null)
     {
         if (!constraint.Matches(actual, out string failure))
         {
@@ -53,7 +53,7 @@ public static class Assert
         }
 
         Fail($"Expected exception of type {typeof(TException).Name} but no exception was thrown.");
-        return null;
+        return null!;
     }
 
     private static void Fail(string message)
@@ -146,7 +146,7 @@ internal sealed class EquivalentConstraint : IConstraint
 
 internal static class ConstraintHelpers
 {
-    public static bool AreEqual(object expected, object actual)
+    public static bool AreEqual(object? expected, object? actual)
     {
         if (ReferenceEquals(expected, actual))
         {
@@ -163,10 +163,10 @@ internal static class ConstraintHelpers
             return expectedString == actualString;
         }
 
-        if (TryGetEnumerable(expected, out IEnumerable expectedEnumerable) &&
-            TryGetEnumerable(actual, out IEnumerable actualEnumerable))
+        if (TryGetEnumerable(expected, out var expectedEnumerable) &&
+            TryGetEnumerable(actual, out var actualEnumerable))
         {
-            return AreSequencesEqual(expectedEnumerable, actualEnumerable);
+            return AreSequencesEqual(expectedEnumerable!, actualEnumerable!);
         }
 
         if (IsNumeric(expected) && IsNumeric(actual))
@@ -177,7 +177,7 @@ internal static class ConstraintHelpers
         return expected.Equals(actual);
     }
 
-    public static string Format(object value)
+    public static string Format(object? value)
     {
         if (value is null)
         {
@@ -189,15 +189,15 @@ internal static class ConstraintHelpers
             return $"\"{s}\"";
         }
 
-        if (TryGetEnumerable(value, out IEnumerable enumerable))
+        if (TryGetEnumerable(value, out var enumerable))
         {
-            return "[" + string.Join(", ", enumerable.Cast<object>().Select(Format)) + "]";
+            return "[" + string.Join(", ", enumerable!.Cast<object>().Select(Format)) + "]";
         }
 
         return Convert.ToString(value, CultureInfo.InvariantCulture) ?? value.ToString() ?? value.GetType().Name;
     }
 
-    private static bool TryGetEnumerable(object value, out IEnumerable enumerable)
+    private static bool TryGetEnumerable(object value, out IEnumerable? enumerable)
     {
         if (value is string)
         {

--- a/src/Paradise.BLOB.Test/TestBlobBuilder.cs
+++ b/src/Paradise.BLOB.Test/TestBlobBuilder.cs
@@ -256,7 +256,7 @@ public class TestBlobBuilder
         MemCmp(ref value, SubBlob(blob.Blob, sizeof(BlobPtr<T>), sizeof(T)));
     }
 
-    unsafe void AssertStringEqual<TEncoding>(string str) where TEncoding : Encoding, new()
+    static unsafe void AssertStringEqual<TEncoding>(string str) where TEncoding : Encoding, new()
     {
         var builder = new StringBuilder<TEncoding>(str);
         var blob = builder.CreateManagedBlobAssetReference();
@@ -268,14 +268,14 @@ public class TestBlobBuilder
 #endif
     }
 
-    byte[] SubBlob(byte[] blob, int startIndex, int length)
+    static byte[] SubBlob(byte[] blob, int startIndex, int length)
     {
         var sub = new byte[length];
         Array.Copy(blob, startIndex, sub, 0, sub.Length);
         return sub;
     }
 
-    byte[] SubBlob(byte[] blob, int startIndex)
+    static byte[] SubBlob(byte[] blob, int startIndex)
     {
         return SubBlob(blob, startIndex, blob.Length - startIndex);
     }
@@ -298,7 +298,7 @@ public class TestBlobBuilder
 
     unsafe byte[] ToBinary<T>(ref T value, int size) where T : unmanaged
     {
-        if (size < 1) throw new ArgumentOutOfRangeException();
+        ArgumentOutOfRangeException.ThrowIfLessThan(size, 1);
 
         var binary = new byte[size];
         fixed(void* source = &value)

--- a/src/Paradise.BLOB.Test/TestBlobDataTypes.cs
+++ b/src/Paradise.BLOB.Test/TestBlobDataTypes.cs
@@ -270,14 +270,15 @@ public class TestBlobNullTerminatedString
     }
 
     [Test]
-    public void should_have_null_terminator_in_data()
+    public unsafe void should_have_null_terminator_in_data()
     {
         const string text = "ABC";
         var builder = new NullTerminatedStringBuilder<UTF8Encoding>(text);
         var blob = builder.CreateManagedBlobAssetReference();
-        // Data.Length should include the null terminator
-        // Length property should exclude it
+        // Length property should exclude the null terminator
         Assert.AreEqual(3, blob.Value.Length);
+        // Verify the null byte actually exists at position Length
+        Assert.AreEqual(0, blob.Value.UnsafePtr[blob.Value.Length]);
     }
 
     [Test]

--- a/src/Paradise.BLOB.Test/TestBlobDataTypes.cs
+++ b/src/Paradise.BLOB.Test/TestBlobDataTypes.cs
@@ -1,0 +1,734 @@
+using System;
+using System.Text;
+
+namespace Paradise.BLOB.Test;
+
+using BlobString = BlobString<UTF8Encoding>;
+using BlobStringBuilder = StringBuilder<UTF8Encoding>;
+
+public class TestBlobArray
+{
+    [Test]
+    public void should_create_empty_array()
+    {
+        var builder = new ArrayBuilder<int>();
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(0, blob.Value.Length);
+        Assert.That(blob.Value.ToArray(), Is.EquivalentTo(Array.Empty<int>()));
+    }
+
+    [Test]
+    public void should_create_single_element_array()
+    {
+        var builder = new ArrayBuilder<int>(new[] { 42 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(1, blob.Value.Length);
+        Assert.AreEqual(42, blob.Value[0]);
+    }
+
+    [Test]
+    public void should_access_elements_by_indexer()
+    {
+        var builder = new ArrayBuilder<int>(new[] { 10, 20, 30, 40, 50 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(5, blob.Value.Length);
+        Assert.AreEqual(10, blob.Value[0]);
+        Assert.AreEqual(20, blob.Value[1]);
+        Assert.AreEqual(30, blob.Value[2]);
+        Assert.AreEqual(40, blob.Value[3]);
+        Assert.AreEqual(50, blob.Value[4]);
+    }
+
+    [Test]
+    public void should_throw_on_negative_index()
+    {
+        var builder = new ArrayBuilder<int>(new[] { 1, 2, 3 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.Catch<ArgumentOutOfRangeException>(() =>
+        {
+            ref var _ = ref blob.Value[-1];
+        });
+    }
+
+    [Test]
+    public void should_throw_on_index_equal_to_length()
+    {
+        var builder = new ArrayBuilder<int>(new[] { 1, 2, 3 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.Catch<ArgumentOutOfRangeException>(() =>
+        {
+            ref var _ = ref blob.Value[3];
+        });
+    }
+
+    [Test]
+    public void should_throw_on_index_greater_than_length()
+    {
+        var builder = new ArrayBuilder<int>(new[] { 1, 2, 3 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.Catch<ArgumentOutOfRangeException>(() =>
+        {
+            ref var _ = ref blob.Value[100];
+        });
+    }
+
+    [Test]
+    public void should_convert_to_array()
+    {
+        var expected = new long[] { 100, 200, 300, 400 };
+        var builder = new ArrayBuilder<long>(expected);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.That(blob.Value.ToArray(), Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void should_convert_empty_to_array()
+    {
+        var builder = new ArrayBuilder<int>();
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.That(blob.Value.ToArray(), Is.EquivalentTo(Array.Empty<int>()));
+    }
+
+    [Test]
+    public void should_convert_to_span()
+    {
+        var expected = new int[] { 1, 2, 3, 4, 5 };
+        var builder = new ArrayBuilder<int>(expected);
+        var blob = builder.CreateManagedBlobAssetReference();
+        var span = blob.Value.ToSpan();
+        Assert.AreEqual(expected.Length, span.Length);
+        for (var i = 0; i < expected.Length; i++)
+            Assert.AreEqual(expected[i], span[i]);
+    }
+
+    [Test]
+    public unsafe void should_provide_unsafe_ptr()
+    {
+        var builder = new ArrayBuilder<int>(new[] { 10, 20, 30 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        var ptr = blob.Value.UnsafePtr;
+        Assert.AreEqual(10, ptr[0]);
+        Assert.AreEqual(20, ptr[1]);
+        Assert.AreEqual(30, ptr[2]);
+    }
+
+    [Test]
+    public void should_work_with_byte_arrays()
+    {
+        var expected = new byte[] { 0, 1, 127, 255 };
+        var builder = new ArrayBuilder<byte>(expected);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(expected.Length, blob.Value.Length);
+        Assert.That(blob.Value.ToArray(), Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void should_work_with_double_arrays()
+    {
+        var expected = new[] { Math.PI, Math.E, double.MaxValue, double.MinValue, 0.0 };
+        var builder = new ArrayBuilder<double>(expected);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(expected.Length, blob.Value.Length);
+        Assert.That(blob.Value.ToArray(), Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void should_return_ref_from_indexer()
+    {
+        var builder = new ArrayBuilder<int>(new[] { 10, 20, 30 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        ref var second = ref blob.Value[1];
+        Assert.AreEqual(20, second);
+        // Modify via ref
+        second = 99;
+        Assert.AreEqual(99, blob.Value[1]);
+    }
+}
+
+public class TestBlobString
+{
+    [Test]
+    public void should_create_empty_string()
+    {
+        var builder = new BlobStringBuilder("");
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual("", blob.Value.ToString());
+        Assert.AreEqual(0, blob.Value.Length);
+    }
+
+    [Test]
+    public void should_create_ascii_string()
+    {
+        var builder = new BlobStringBuilder("Hello World");
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual("Hello World", blob.Value.ToString());
+        Assert.AreEqual(new UTF8Encoding().GetByteCount("Hello World"), blob.Value.Length);
+    }
+
+    [Test]
+    public void should_create_unicode_string()
+    {
+        const string text = "こんにちは世界";
+        var builder = new BlobStringBuilder(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+    }
+
+    [Test]
+    public void should_create_chinese_string()
+    {
+        const string text = "放大镜考过托福热情";
+        var builder = new BlobStringBuilder(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+    }
+
+    [Test]
+    public void should_roundtrip_with_unicode_encoding()
+    {
+        const string text = "Hello Unicode 日本語";
+        var builder = new StringBuilder<UnicodeEncoding>(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+        Assert.AreEqual(new UnicodeEncoding().GetByteCount(text), blob.Value.Length);
+    }
+
+    [Test]
+    public void should_roundtrip_with_utf32_encoding()
+    {
+        const string text = "UTF-32 test 测试";
+        var builder = new StringBuilder<UTF32Encoding>(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+        Assert.AreEqual(new UTF32Encoding().GetByteCount(text), blob.Value.Length);
+    }
+
+    [Test]
+    public void should_provide_span()
+    {
+        const string text = "Span test";
+        var builder = new BlobStringBuilder(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        var span = blob.Value.ToSpan();
+        var expected = new UTF8Encoding().GetBytes(text);
+        Assert.AreEqual(expected.Length, span.Length);
+        for (var i = 0; i < expected.Length; i++)
+            Assert.AreEqual(expected[i], span[i]);
+    }
+
+    [Test]
+    public unsafe void should_provide_unsafe_ptr()
+    {
+        const string text = "ABC";
+        var builder = new BlobStringBuilder(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        var ptr = blob.Value.UnsafePtr;
+        Assert.AreEqual((byte)'A', ptr[0]);
+        Assert.AreEqual((byte)'B', ptr[1]);
+        Assert.AreEqual((byte)'C', ptr[2]);
+    }
+
+    [Test]
+    public void should_handle_default_builder()
+    {
+        var builder = new BlobStringBuilder();
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual("", blob.Value.ToString());
+        Assert.AreEqual(0, blob.Value.Length);
+    }
+}
+
+public class TestBlobNullTerminatedString
+{
+    [Test]
+    public void should_create_empty_null_terminated_string()
+    {
+        var builder = new NullTerminatedStringBuilder<UTF8Encoding>("");
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual("", blob.Value.ToString());
+        Assert.AreEqual(0, blob.Value.Length);
+    }
+
+    [Test]
+    public void should_create_ascii_null_terminated_string()
+    {
+        const string text = "Hello";
+        var builder = new NullTerminatedStringBuilder<UTF8Encoding>(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+        // Length should be the byte count without null terminator
+        Assert.AreEqual(new UTF8Encoding().GetByteCount(text), blob.Value.Length);
+    }
+
+    [Test]
+    public void should_create_unicode_null_terminated_string()
+    {
+        const string text = "日本語テスト";
+        var builder = new NullTerminatedStringBuilder<UTF8Encoding>(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+    }
+
+    [Test]
+    public void should_have_null_terminator_in_data()
+    {
+        const string text = "ABC";
+        var builder = new NullTerminatedStringBuilder<UTF8Encoding>(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        // Data.Length should include the null terminator
+        // Length property should exclude it
+        Assert.AreEqual(3, blob.Value.Length);
+    }
+
+    [Test]
+    public void should_roundtrip_with_unicode_encoding()
+    {
+        const string text = "Unicode null-terminated 测试";
+        var builder = new NullTerminatedStringBuilder<UnicodeEncoding>(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+    }
+
+    [Test]
+    public void should_provide_span()
+    {
+        const string text = "Span test";
+        var builder = new NullTerminatedStringBuilder<UTF8Encoding>(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        var span = blob.Value.ToSpan();
+        var expected = new UTF8Encoding().GetBytes(text);
+        Assert.AreEqual(expected.Length, span.Length);
+        for (var i = 0; i < expected.Length; i++)
+            Assert.AreEqual(expected[i], span[i]);
+    }
+
+    [Test]
+    public unsafe void should_provide_unsafe_ptr()
+    {
+        const string text = "XYZ";
+        var builder = new NullTerminatedStringBuilder<UTF8Encoding>(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        var ptr = blob.Value.UnsafePtr;
+        Assert.AreEqual((byte)'X', ptr[0]);
+        Assert.AreEqual((byte)'Y', ptr[1]);
+        Assert.AreEqual((byte)'Z', ptr[2]);
+    }
+
+    [Test]
+    public void should_handle_default_builder()
+    {
+        var builder = new NullTerminatedStringBuilder<UTF8Encoding>();
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual("", blob.Value.ToString());
+        Assert.AreEqual(0, blob.Value.Length);
+    }
+}
+
+public class TestBlobPtr
+{
+    [Test]
+    public void should_dereference_int_value()
+    {
+        var builder = new PtrBuilderWithNewValue<int>(42);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value.Value);
+    }
+
+    [Test]
+    public void should_dereference_long_value()
+    {
+        var builder = new PtrBuilderWithNewValue<long>(long.MaxValue);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(long.MaxValue, blob.Value.Value);
+    }
+
+    [Test]
+    public void should_dereference_double_value()
+    {
+        var builder = new PtrBuilderWithNewValue<double>(Math.PI);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(Math.PI, blob.Value.Value);
+    }
+
+    [Test]
+    public void should_dereference_byte_value()
+    {
+        var builder = new PtrBuilderWithNewValue<byte>(255);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(255, blob.Value.Value);
+    }
+
+    [Test]
+    public unsafe void should_provide_unsafe_ptr()
+    {
+        var builder = new PtrBuilderWithNewValue<int>(99);
+        var blob = builder.CreateManagedBlobAssetReference();
+        var ptr = blob.Value.UnsafePtr;
+        Assert.AreEqual(99, *ptr);
+    }
+
+    [Test]
+    public void should_return_ref_from_value()
+    {
+        var builder = new PtrBuilderWithNewValue<int>(50);
+        var blob = builder.CreateManagedBlobAssetReference();
+        ref var val = ref blob.Value.Value;
+        Assert.AreEqual(50, val);
+        // Modify via ref
+        val = 100;
+        Assert.AreEqual(100, blob.Value.Value);
+    }
+
+    struct SimpleStruct
+    {
+        public int A;
+        public float B;
+    }
+
+    [Test]
+    public void should_dereference_struct_value()
+    {
+        var builder = new PtrBuilderWithNewValue<SimpleStruct>(new SimpleStruct { A = 10, B = 3.14f });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(10, blob.Value.Value.A);
+        Assert.AreEqual(3.14f, blob.Value.Value.B);
+    }
+
+    struct StructWithSelfPtr
+    {
+        public int Value;
+        public BlobPtr<int> Ptr;
+    }
+
+    [Test]
+    public void should_work_with_ref_builder_pointing_to_struct_field()
+    {
+        var builder = new StructBuilder<StructWithSelfPtr>();
+        var valueBuilder = builder.SetValue(ref builder.Value.Value, 42);
+        builder.SetPointer(ref builder.Value.Ptr, valueBuilder);
+
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value.Value);
+        Assert.AreEqual(42, blob.Value.Ptr.Value);
+    }
+
+    [Test]
+    public void should_dereference_ptr_to_ptr()
+    {
+        var innerBuilder = new PtrBuilderWithNewValue<int>(777);
+        var outerBuilder = new PtrBuilderWithNewValue<BlobPtr<int>>(innerBuilder);
+        var blob = outerBuilder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(777, blob.Value.Value.Value);
+    }
+
+    struct StructWithPtrToArray
+    {
+        public BlobArray<int> Array;
+        public BlobPtr<BlobArray<int>> Ptr;
+    }
+
+    [Test]
+    public void should_dereference_ptr_to_array()
+    {
+        var builder = new StructBuilder<StructWithPtrToArray>();
+        var arrayBuilder = builder.SetArray(ref builder.Value.Array, new[] { 10, 20, 30 });
+        builder.SetPointer(ref builder.Value.Ptr, arrayBuilder);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(3, blob.Value.Ptr.Value.Length);
+        Assert.That(blob.Value.Ptr.Value.ToArray(), Is.EquivalentTo(new[] { 10, 20, 30 }));
+    }
+
+    [Test]
+    public void should_dereference_ptr_to_string()
+    {
+        const string text = "Hello Ptr";
+        var stringBuilder = new BlobStringBuilder(text);
+        var ptrBuilder = new PtrBuilderWithNewValue<BlobString>(stringBuilder);
+        var blob = ptrBuilder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.Value.ToString());
+    }
+}
+
+public class TestBlobPtrAny
+{
+    [Test]
+    public void should_get_int_value()
+    {
+        var builder = new AnyPtrBuilder<int>(42);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value.GetValue<int>());
+        Assert.AreEqual(sizeof(int), blob.Value.Size);
+    }
+
+    [Test]
+    public void should_get_long_value()
+    {
+        var builder = new AnyPtrBuilder<long>(long.MaxValue);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(long.MaxValue, blob.Value.GetValue<long>());
+        Assert.AreEqual(sizeof(long), blob.Value.Size);
+    }
+
+    [Test]
+    public unsafe void should_throw_on_wrong_type_size()
+    {
+        var builder = new AnyPtrBuilder<int>(42);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.Catch<ArgumentException>(() =>
+        {
+            blob.Value.GetUnsafeValuePtr<long>();
+        });
+    }
+
+    [Test]
+    public void should_update_value_and_rebuild()
+    {
+        var builder = new AnyPtrBuilder<int>(100);
+        builder.SetValue(200);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(200, blob.Value.GetValue<int>());
+    }
+
+    [Test]
+    public void should_change_type_via_any_builder()
+    {
+        var builder = new AnyPtrBuilder();
+        builder.SetValue(42);
+        var blob1 = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob1.Value.GetValue<int>());
+        Assert.AreEqual(sizeof(int), blob1.Value.Size);
+
+        builder.SetValue(long.MaxValue);
+        var blob2 = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(long.MaxValue, blob2.Value.GetValue<long>());
+        Assert.AreEqual(sizeof(long), blob2.Value.Size);
+    }
+
+    [Test]
+    public unsafe void should_provide_unsafe_ptr()
+    {
+        var builder = new AnyPtrBuilder<int>(99);
+        var blob = builder.CreateManagedBlobAssetReference();
+        var ptr = blob.Value.UnsafePtr;
+        Assert.AreEqual(99, *(int*)ptr);
+    }
+}
+
+public class TestBlobArrayAny
+{
+    [Test]
+    public void should_get_values_of_different_types()
+    {
+        var builder = new AnyArrayBuilder();
+        builder.Add(42);
+        builder.Add(3.14);
+        builder.Add(100L);
+
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(3, blob.Value.Length);
+        Assert.AreEqual(42, blob.Value.GetValue<int>(0));
+        Assert.AreEqual(3.14, blob.Value.GetValue<double>(1));
+        Assert.AreEqual(100L, blob.Value.GetValue<long>(2));
+    }
+
+    [Test]
+    public void should_get_sizes_of_different_types()
+    {
+        var builder = new AnyArrayBuilder();
+        builder.Add(42);
+        builder.Add(3.14);
+
+        var blob = builder.CreateManagedBlobAssetReference();
+        // Size includes alignment padding between items
+        Assert.GreaterOrEqual(blob.Value.GetSize(0), sizeof(int));
+        Assert.GreaterOrEqual(blob.Value.GetSize(1), sizeof(double));
+    }
+
+    [Test]
+    public void should_get_offsets()
+    {
+        var builder = new AnyArrayBuilder();
+        builder.Add(42);
+        builder.Add(100L);
+
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(0, blob.Value.GetOffset(0));
+    }
+
+    [Test]
+    public unsafe void should_throw_on_wrong_type_size()
+    {
+        var builder = new AnyArrayBuilder();
+        builder.Add(42);
+
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.Catch<ArgumentException>(() =>
+        {
+            blob.Value.GetUnsafeValuePtr<long>(0);
+        });
+    }
+
+    [Test]
+    public void should_handle_complex_items()
+    {
+        var builder = new AnyArrayBuilder();
+        builder.Add(new PtrBuilderWithNewValue<int>(999));
+        builder.Add(new ArrayBuilder<int>(new[] { 1, 2, 3 }));
+
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(2, blob.Value.Length);
+        Assert.AreEqual(999, blob.Value.GetValue<BlobPtr<int>>(0).Value);
+        Assert.That(blob.Value.GetValue<BlobArray<int>>(1).ToArray(), Is.EquivalentTo(new[] { 1, 2, 3 }));
+    }
+}
+
+public class TestBlobSortedArrayEdgeCases
+{
+    [Test]
+    public void should_return_negative_index_for_missing_key()
+    {
+        var map = new Dictionary<int, int>
+        {
+            { 1, 100 },
+            { 2, 200 },
+            { 3, 300 },
+        };
+        var builder = new SortedArrayBuilder<int, int>(map);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(-1, blob.Value.IndexOfKey(999));
+    }
+
+    [Test]
+    public void should_find_key_by_index()
+    {
+        var map = new Dictionary<int, int>
+        {
+            { 10, 100 },
+            { 20, 200 },
+            { 30, 300 },
+        };
+        var builder = new SortedArrayBuilder<int, int>(map);
+        var blob = builder.CreateManagedBlobAssetReference();
+        foreach (var pair in map)
+        {
+            var index = blob.Value.IndexOfKey(pair.Key);
+            Assert.GreaterOrEqual(index, 0, $"Key {pair.Key} should be found");
+        }
+    }
+
+    [Test]
+    public void should_throw_on_missing_key_via_indexer()
+    {
+        var map = new Dictionary<int, int> { { 1, 100 } };
+        var builder = new SortedArrayBuilder<int, int>(map);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.Catch<ArgumentException>(() =>
+        {
+            ref var _ = ref blob.Value[999];
+        });
+    }
+
+    [Test]
+    public void should_create_from_enumerable_of_tuples()
+    {
+        var items = new (int key, int value)[] { (1, 10), (2, 20), (3, 30) };
+        var builder = new SortedArrayBuilder<int, int>(items);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(3, blob.Value.Length);
+        Assert.AreEqual(10, blob.Value[1]);
+        Assert.AreEqual(20, blob.Value[2]);
+        Assert.AreEqual(30, blob.Value[3]);
+    }
+
+    [Test]
+    public void should_create_from_builder_tuples()
+    {
+        var items = new (int key, IBuilder<int> builder)[]
+        {
+            (1, new ValueBuilder<int>(10)),
+            (2, new ValueBuilder<int>(20)),
+        };
+        var builder = new SortedArrayBuilder<int, int>(items);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(2, blob.Value.Length);
+        Assert.AreEqual(10, blob.Value[1]);
+        Assert.AreEqual(20, blob.Value[2]);
+    }
+
+    [Test]
+    public void should_handle_single_element()
+    {
+        var map = new Dictionary<int, int> { { 42, 999 } };
+        var builder = new SortedArrayBuilder<int, int>(map);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(1, blob.Value.Length);
+        Assert.AreEqual(999, blob.Value[42]);
+    }
+
+    [Test]
+    public void should_expose_builders_via_property()
+    {
+        var items = new (int key, IBuilder<int> builder)[]
+        {
+            (1, new ValueBuilder<int>(10)),
+            (2, new ValueBuilder<int>(20)),
+        };
+        var builder = new SortedArrayBuilder<int, int>(items);
+        Assert.AreEqual(2, builder.Builders.Count);
+        Assert.IsNotNull(builder[1]);
+        Assert.IsNotNull(builder[2]);
+    }
+}
+
+public class TestUnityBlobString
+{
+    [Test]
+    public void should_create_empty_unity_string()
+    {
+        var builder = new UnityStringBuilder("");
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual("", blob.Value.ToString());
+        Assert.AreEqual(0, blob.Value.Length);
+    }
+
+    [Test]
+    public void should_create_ascii_unity_string()
+    {
+        const string text = "Hello Unity";
+        var builder = new UnityStringBuilder(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+        Assert.AreEqual(new UTF8Encoding().GetByteCount(text), blob.Value.Length);
+    }
+
+    [Test]
+    public void should_create_unicode_unity_string()
+    {
+        const string text = "日本語テスト";
+        var builder = new UnityStringBuilder(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(text, blob.Value.ToString());
+    }
+
+    [Test]
+    public void should_provide_span()
+    {
+        const string text = "Span";
+        var builder = new UnityStringBuilder(text);
+        var blob = builder.CreateManagedBlobAssetReference();
+        var span = blob.Value.ToSpan();
+        var expected = new UTF8Encoding().GetBytes(text);
+        Assert.AreEqual(expected.Length, span.Length);
+        for (var i = 0; i < expected.Length; i++)
+            Assert.AreEqual(expected[i], span[i]);
+    }
+
+    [Test]
+    public void should_handle_default_builder()
+    {
+        var builder = new UnityStringBuilder();
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual("", blob.Value.ToString());
+        Assert.AreEqual(0, blob.Value.Length);
+    }
+}

--- a/src/Paradise.BLOB.Test/TestBlobSortedArray.cs
+++ b/src/Paradise.BLOB.Test/TestBlobSortedArray.cs
@@ -20,7 +20,7 @@ public class TestBlobSortedArray
             return Value == other.Value;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Key other && Equals(other);
         }

--- a/src/Paradise.BLOB.Test/TestBlobTree.cs
+++ b/src/Paradise.BLOB.Test/TestBlobTree.cs
@@ -33,7 +33,7 @@ public class TestBlobTree
             {
                 _parent?.InternalChildren.Remove(this);
                 _parent = value;
-                _parent!.InternalChildren.Add(this);
+                _parent?.InternalChildren.Add(this);
             }
         }
 

--- a/src/Paradise.BLOB.Test/TestBlobTree.cs
+++ b/src/Paradise.BLOB.Test/TestBlobTree.cs
@@ -17,23 +17,23 @@ public class TestBlobTree
         return Enumerable.Range(0, 10);
     }
 
-    class TreeNode<T> : ITreeNode<T> where T : unmanaged
+    sealed class TreeNode<T> : ITreeNode<T> where T : unmanaged
     {
         internal readonly List<TreeNode<T>> InternalChildren = new List<TreeNode<T>>();
-        private TreeNode<T> _parent;
+        private TreeNode<T>? _parent;
 
         public IBuilder<T> ValueBuilder { get; }
         public int BlobIndex { get; set; } = -1;
         public IReadOnlyList<ITreeNode<T>> Children => InternalChildren;
 
-        public TreeNode<T> Parent
+        public TreeNode<T>? Parent
         {
             get => _parent;
             set
             {
                 _parent?.InternalChildren.Remove(this);
                 _parent = value;
-                _parent.InternalChildren.Add(this);
+                _parent!.InternalChildren.Add(this);
             }
         }
 
@@ -69,7 +69,7 @@ public class TestBlobTree
         return RandomTree(tree, seed);
     }
 
-    void CompareTree<T>(ref BlobTree<T> blobTree, IReadOnlyList<TreeNode<T>> tree) where T : unmanaged
+    static void CompareTree<T>(ref BlobTree<T> blobTree, IReadOnlyList<TreeNode<T>> tree) where T : unmanaged
     {
         Assert.That(blobTree.Length, Is.EqualTo(tree.Count));
         foreach (var node in tree)
@@ -79,7 +79,7 @@ public class TestBlobTree
         }
     }
 
-    void CompareBlobNodeWithBuildNode<T>(in BlobTree<T>.Node blobNode, TreeNode<T> buildNode) where T : unmanaged
+    static void CompareBlobNodeWithBuildNode<T>(in BlobTree<T>.Node blobNode, TreeNode<T> buildNode) where T : unmanaged
     {
         // Assert.That(blobNode.ValueBuilder, Is.EqualTo(buildNode.ValueBuilder));
         Assert.That(blobNode.FindParentIndex(), Is.EqualTo(buildNode.ParentIndex));

--- a/src/Paradise.BLOB.Test/TestBlobTreeAny.cs
+++ b/src/Paradise.BLOB.Test/TestBlobTreeAny.cs
@@ -17,24 +17,24 @@ public class TestBlobTreeAny
         return Enumerable.Range(0, 10);
     }
 
-    class TreeNode : ITreeNode
+    sealed class TreeNode : ITreeNode
     {
         internal readonly List<TreeNode> InternalChildren = new List<TreeNode>();
-        private TreeNode _parent;
+        private TreeNode? _parent;
 
         public int BlobIndex { get; set; }
         public IBuilder ValueBuilder { get; set; }
 
         IReadOnlyList<ITreeNode> ITreeNode.Children => InternalChildren;
 
-        public TreeNode Parent
+        public TreeNode? Parent
         {
             get => _parent;
             set
             {
                 _parent?.InternalChildren.Remove(this);
                 _parent = value;
-                _parent.InternalChildren.Add(this);
+                _parent!.InternalChildren.Add(this);
             }
         }
 
@@ -62,13 +62,13 @@ public class TestBlobTreeAny
         }
     }
 
-    IReadOnlyList<TreeNode> CreateRandomIntTree(int count, int seed)
+    static IReadOnlyList<TreeNode> CreateRandomIntTree(int count, int seed)
     {
         var tree = Enumerable.Range(0, count).Select(value => new TreeNode(new ValueBuilder<int>((value + 1) * 100))).ToArray();
         return RandomTree(tree, seed);
     }
 
-    void CompareTree(ref BlobTreeAny blobTree, IReadOnlyList<TreeNode> tree)
+    static void CompareTree(ref BlobTreeAny blobTree, IReadOnlyList<TreeNode> tree)
     {
         Assert.That(blobTree.Length, Is.EqualTo(tree.Count));
         foreach (var node in tree)
@@ -78,7 +78,7 @@ public class TestBlobTreeAny
         }
     }
 
-    void CompareBlobNodeWithBuildNode(in BlobTreeAny.Node blobNode, TreeNode buildNode)
+    static void CompareBlobNodeWithBuildNode(in BlobTreeAny.Node blobNode, TreeNode buildNode)
     {
         // Assert.That(blobNode.ValueBuilder, Is.EqualTo(buildNode.ValueBuilder));
         Assert.That(blobNode.FindParentIndex(), Is.EqualTo(buildNode.ParentIndex));
@@ -183,12 +183,12 @@ public class TestBlobTreeAny
         }
     }
 
-    IReadOnlyList<TreeNode> RandomTree(IReadOnlyList<TreeNode> nodes)
+    static IReadOnlyList<TreeNode> RandomTree(IReadOnlyList<TreeNode> nodes)
     {
         return RandomTree(nodes, Environment.TickCount);
     }
 
-    IReadOnlyList<TreeNode> RandomTree(IReadOnlyList<TreeNode> nodes, int seed)
+    static IReadOnlyList<TreeNode> RandomTree(IReadOnlyList<TreeNode> nodes, int seed)
     {
         var random = new Random(seed);
         for (var i = 1; i < nodes.Count; i++)
@@ -200,7 +200,7 @@ public class TestBlobTreeAny
         return nodes;
     }
 
-    int SetBlobIndex(TreeNode root, int index = 0)
+    static int SetBlobIndex(TreeNode root, int index = 0)
     {
         root.BlobIndex = index;
         foreach (var child in root.InternalChildren) index = SetBlobIndex(child, index + 1);

--- a/src/Paradise.BLOB.Test/TestBlobTreeAny.cs
+++ b/src/Paradise.BLOB.Test/TestBlobTreeAny.cs
@@ -34,7 +34,7 @@ public class TestBlobTreeAny
             {
                 _parent?.InternalChildren.Remove(this);
                 _parent = value;
-                _parent!.InternalChildren.Add(this);
+                _parent?.InternalChildren.Add(this);
             }
         }
 

--- a/src/Paradise.BLOB.Test/TestBuilderAndStream.cs
+++ b/src/Paradise.BLOB.Test/TestBuilderAndStream.cs
@@ -541,15 +541,23 @@ public class TestPtrBuilderVariants
         Assert.IsNotNull(builder.ValueBuilder);
     }
 
-    [Test]
-    public void should_build_ref_ptr()
+    struct StructWithRefPtr
     {
-        var structBuilder = new ValueBuilder<int>(100);
-        var ptrBuilder = new PtrBuilderWithRefBuilder<int>(structBuilder);
-        // PtrBuilderWithRefBuilder references existing data position
-        var blob = ptrBuilder.CreateManagedBlobAssetReference();
-        // This tests the pointer resolution mechanics
-        Assert.IsNotNull(blob);
+        public int Value;
+        public BlobPtr<int> Ptr;
+    }
+
+    [Test]
+    public void should_build_ref_ptr_in_struct_context()
+    {
+        // PtrBuilderWithRefBuilder requires composition inside a StructBuilder
+        // because it resolves a self-relative offset to another builder's data position
+        var builder = new StructBuilder<StructWithRefPtr>();
+        var valueBuilder = builder.SetValue(ref builder.Value.Value, 100);
+        builder.SetPointer(ref builder.Value.Ptr, valueBuilder);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(100, blob.Value.Value);
+        Assert.AreEqual(100, blob.Value.Ptr.Value);
     }
 
     [Test]

--- a/src/Paradise.BLOB.Test/TestBuilderAndStream.cs
+++ b/src/Paradise.BLOB.Test/TestBuilderAndStream.cs
@@ -1,0 +1,822 @@
+using System;
+using System.Text;
+
+namespace Paradise.BLOB.Test;
+
+using BlobString = BlobString<UTF8Encoding>;
+using BlobStringBuilder = StringBuilder<UTF8Encoding>;
+
+public class TestBlobMemoryStream
+{
+    [Test]
+    public void should_have_default_capacity()
+    {
+        using var stream = new BlobMemoryStream();
+        Assert.AreEqual(0, stream.Position);
+        Assert.AreEqual(0, stream.Length);
+    }
+
+    [Test]
+    public void should_accept_custom_capacity()
+    {
+        using var stream = new BlobMemoryStream(256);
+        Assert.AreEqual(0, stream.Position);
+        Assert.AreEqual(0, stream.Length);
+    }
+
+    [Test]
+    public void should_set_and_get_position()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 100;
+        stream.Position = 50;
+        Assert.AreEqual(50, stream.Position);
+    }
+
+    [Test]
+    public void should_set_and_get_length()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 200;
+        Assert.AreEqual(200, stream.Length);
+    }
+
+    [Test]
+    public void should_default_alignment_to_4()
+    {
+        using var stream = new BlobMemoryStream();
+        Assert.AreEqual(4, stream.Alignment);
+    }
+
+    [Test]
+    public void should_allow_setting_alignment()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Alignment = 8;
+        Assert.AreEqual(8, stream.Alignment);
+    }
+
+    [Test]
+    public unsafe void should_write_and_read_back()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 16;
+        int value = 12345;
+        stream.Write((byte*)&value, sizeof(int), 4);
+        var arr = stream.ToArray();
+        Assert.AreEqual(16, arr.Length);
+        fixed (byte* ptr = arr)
+        {
+            Assert.AreEqual(12345, *(int*)ptr);
+        }
+    }
+
+    [Test]
+    public void should_grow_capacity_on_write()
+    {
+        using var stream = new BlobMemoryStream(4);
+        stream.EnsureDataSize(1024, 4);
+        Assert.GreaterOrEqual(stream.Length, 1024);
+    }
+
+    [Test]
+    public void should_return_correct_array()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 8;
+        var arr = stream.ToArray();
+        Assert.AreEqual(8, arr.Length);
+    }
+
+    [Test]
+    public void should_provide_buffer()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 4;
+        Assert.IsNotNull(stream.Buffer);
+        Assert.GreaterOrEqual(stream.Buffer.Length, 4);
+    }
+
+    [Test]
+    public void should_track_patch_position()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.PatchPosition = 16;
+        Assert.AreEqual(16, stream.PatchPosition);
+    }
+
+    [Test]
+    public void should_update_patch_position_on_write()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.EnsureDataSize(8, 4);
+        Assert.GreaterOrEqual(stream.PatchPosition, 8);
+    }
+}
+
+public class TestBlobStreamExtension
+{
+    [Test]
+    public void should_ensure_data_size_and_expand()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.EnsureDataSize(32, 4);
+        Assert.GreaterOrEqual(stream.Length, 32);
+        Assert.GreaterOrEqual(stream.PatchPosition, 32);
+    }
+
+    [Test]
+    public void should_ensure_data_size_generic()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.EnsureDataSize<long>();
+        Assert.GreaterOrEqual(stream.Length, sizeof(long));
+    }
+
+    [Test]
+    public void should_expand_patch()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.PatchPosition = 8;
+        stream.ExpandPatch(16, 4);
+        Assert.GreaterOrEqual(stream.PatchPosition, 24);
+    }
+
+    [Test]
+    public void should_align_patch()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.PatchPosition = 5;
+        stream.AlignPatch(4);
+        Assert.AreEqual(8, stream.PatchPosition);
+    }
+
+    [Test]
+    public unsafe void should_write_value_generic()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 16;
+        stream.WriteValue(42);
+        var arr = stream.ToArray();
+        fixed (byte* ptr = arr)
+        {
+            Assert.AreEqual(42, *(int*)ptr);
+        }
+    }
+
+    [Test]
+    public void should_write_offset()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 16;
+        stream.Position = 0;
+        stream.WriteOffset(8);
+        var arr = stream.ToArray();
+        // Offset should be 8 - 0 = 8
+        Assert.AreEqual(8, BitConverter.ToInt32(arr, 0));
+    }
+
+    [Test]
+    public void should_calculate_offset()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Position = 4;
+        Assert.AreEqual(12, stream.Offset(16));
+    }
+
+    [Test]
+    public void should_calculate_patch_offset()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Position = 0;
+        stream.PatchPosition = 20;
+        Assert.AreEqual(20, stream.PatchOffset());
+    }
+
+    [Test]
+    public void should_to_position()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 100;
+        stream.ToPosition(50);
+        Assert.AreEqual(50, stream.Position);
+    }
+
+    [Test]
+    public void should_to_patch_position()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.PatchPosition = 32;
+        stream.Length = 64;
+        stream.ToPatchPosition();
+        Assert.AreEqual(32, stream.Position);
+    }
+
+    [Test]
+    public void should_get_alignment_with_positive_value()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Alignment = 4;
+        Assert.AreEqual(8, stream.GetAlignment(8));
+    }
+
+    [Test]
+    public void should_get_alignment_with_zero_uses_stream_default()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Alignment = 4;
+        Assert.AreEqual(4, stream.GetAlignment(0));
+    }
+}
+
+public class TestValueBuilder
+{
+    [Test]
+    public void should_build_default_value()
+    {
+        var builder = new ValueBuilder<int>();
+        Assert.AreEqual(0, builder.Value);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(0, blob.Value);
+    }
+
+    [Test]
+    public void should_build_specified_value()
+    {
+        var builder = new ValueBuilder<int>(42);
+        Assert.AreEqual(42, builder.Value);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value);
+    }
+
+    [Test]
+    public void should_allow_modifying_value_before_build()
+    {
+        var builder = new ValueBuilder<int>(10);
+        builder.Value = 99;
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(99, blob.Value);
+    }
+
+    [Test]
+    public void should_build_float_value()
+    {
+        var builder = new ValueBuilder<float>(3.14f);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(3.14f, blob.Value);
+    }
+
+    [Test]
+    public void should_build_long_value()
+    {
+        var builder = new ValueBuilder<long>(long.MaxValue);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(long.MaxValue, blob.Value);
+    }
+
+    [Test]
+    public void should_build_byte_value()
+    {
+        var builder = new ValueBuilder<byte>(255);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(255, blob.Value);
+    }
+
+    struct TestStruct
+    {
+        public int X;
+        public float Y;
+        public byte Z;
+    }
+
+    [Test]
+    public void should_build_struct_value()
+    {
+        var builder = new ValueBuilder<TestStruct>(new TestStruct { X = 1, Y = 2.5f, Z = 3 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(1, blob.Value.X);
+        Assert.AreEqual(2.5f, blob.Value.Y);
+        Assert.AreEqual(3, blob.Value.Z);
+    }
+
+    [Test]
+    public void should_track_data_position_and_size()
+    {
+        var builder = new ValueBuilder<int>(42);
+        using var stream = new BlobMemoryStream();
+        builder.Build(stream);
+        Assert.AreEqual(0, builder.DataPosition);
+        Assert.AreEqual(sizeof(int), builder.DataSize);
+    }
+}
+
+public class TestStructBuilder
+{
+    struct SimpleStruct
+    {
+        public int A;
+        public float B;
+    }
+
+    [Test]
+    public void should_build_struct_with_set_values()
+    {
+        var builder = new StructBuilder<SimpleStruct>();
+        builder.SetValue(ref builder.Value.A, 42);
+        builder.SetValue(ref builder.Value.B, 3.14f);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value.A);
+        Assert.AreEqual(3.14f, blob.Value.B);
+    }
+
+    [Test]
+    public void should_get_builder_for_field()
+    {
+        var builder = new StructBuilder<SimpleStruct>();
+        builder.SetValue(ref builder.Value.A, 42);
+        var fieldBuilder = builder.GetBuilder(ref builder.Value.A);
+        Assert.IsNotNull(fieldBuilder);
+    }
+
+    struct StructWithArray
+    {
+        public int Value;
+        public BlobArray<int> Array;
+    }
+
+    [Test]
+    public void should_build_struct_with_array()
+    {
+        var builder = new StructBuilder<StructWithArray>();
+        builder.SetValue(ref builder.Value.Value, 100);
+        builder.SetArray(ref builder.Value.Array, new[] { 1, 2, 3 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(100, blob.Value.Value);
+        Assert.AreEqual(3, blob.Value.Array.Length);
+        Assert.That(blob.Value.Array.ToArray(), Is.EquivalentTo(new[] { 1, 2, 3 }));
+    }
+
+    struct StructWithPtr
+    {
+        public int Value;
+        public BlobPtr<int> Ptr;
+    }
+
+    [Test]
+    public void should_build_struct_with_pointer_to_field()
+    {
+        var builder = new StructBuilder<StructWithPtr>();
+        var valueBuilder = builder.SetValue(ref builder.Value.Value, 42);
+        builder.SetPointer(ref builder.Value.Ptr, valueBuilder);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value.Value);
+        Assert.AreEqual(42, blob.Value.Ptr.Value);
+    }
+
+    [Test]
+    public void should_build_struct_with_pointer_to_new_value()
+    {
+        var builder = new StructBuilder<StructWithPtr>();
+        builder.SetValue(ref builder.Value.Value, 10);
+        builder.SetPointer(ref builder.Value.Ptr, 99);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(10, blob.Value.Value);
+        Assert.AreEqual(99, blob.Value.Ptr.Value);
+    }
+
+    struct StructWithString
+    {
+        public BlobString String;
+        public int Value;
+    }
+
+    [Test]
+    public void should_build_struct_with_string()
+    {
+        var builder = new StructBuilder<StructWithString>();
+        builder.SetString(ref builder.Value.String, "Hello");
+        builder.SetValue(ref builder.Value.Value, 42);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual("Hello", blob.Value.String.ToString());
+        Assert.AreEqual(42, blob.Value.Value);
+    }
+
+    [Test]
+    public void should_override_field_with_later_set()
+    {
+        var builder = new StructBuilder<SimpleStruct>();
+        builder.SetValue(ref builder.Value.A, 10);
+        builder.SetValue(ref builder.Value.A, 20);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(20, blob.Value.A);
+    }
+
+    struct StructWithArrayBuilders
+    {
+        public BlobArray<BlobPtr<int>> PtrArray;
+    }
+
+    [Test]
+    public void should_build_struct_with_array_of_builders()
+    {
+        var builder = new StructBuilder<StructWithArrayBuilders>();
+        var itemBuilders = new IBuilder<BlobPtr<int>>[]
+        {
+            new PtrBuilderWithNewValue<int>(10),
+            new PtrBuilderWithNewValue<int>(20),
+            new PtrBuilderWithNewValue<int>(30),
+        };
+        builder.SetArray(ref builder.Value.PtrArray, itemBuilders);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(3, blob.Value.PtrArray.Length);
+        Assert.AreEqual(10, blob.Value.PtrArray[0].Value);
+        Assert.AreEqual(20, blob.Value.PtrArray[1].Value);
+        Assert.AreEqual(30, blob.Value.PtrArray[2].Value);
+    }
+}
+
+public class TestArrayBuilderVariants
+{
+    [Test]
+    public void should_build_from_enumerable()
+    {
+        IEnumerable<int> items = new List<int> { 1, 2, 3 };
+        var builder = new ArrayBuilder<int>(items);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(3, blob.Value.Length);
+        Assert.That(blob.Value.ToArray(), Is.EquivalentTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void should_build_empty_array()
+    {
+        var builder = new ArrayBuilder<int>();
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(0, blob.Value.Length);
+    }
+
+    [Test]
+    public void should_build_with_item_builders()
+    {
+        var builders = new IBuilder<BlobPtr<int>>[]
+        {
+            new PtrBuilderWithNewValue<int>(100),
+            new PtrBuilderWithNewValue<int>(200),
+        };
+        var builder = new ArrayBuilderWithItemBuilders<BlobPtr<int>>(builders);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(2, blob.Value.Length);
+        Assert.AreEqual(100, blob.Value[0].Value);
+        Assert.AreEqual(200, blob.Value[1].Value);
+    }
+
+    [Test]
+    public void should_access_item_builders_by_index()
+    {
+        var builders = new IBuilder<int>[]
+        {
+            new ValueBuilder<int>(10),
+            new ValueBuilder<int>(20),
+        };
+        var builder = new ArrayBuilderWithItemBuilders<int>(builders);
+        Assert.IsNotNull(builder[0]);
+        Assert.IsNotNull(builder[1]);
+    }
+
+    [Test]
+    public void should_build_with_item_position()
+    {
+        var builder = new ArrayBuilderWithItemPosition<float>(new[] { 1f, 2f, 3f });
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(3, blob.Value.Length);
+        Assert.AreEqual(1f, blob.Value[0]);
+        Assert.AreEqual(2f, blob.Value[1]);
+        Assert.AreEqual(3f, blob.Value[2]);
+    }
+
+    [Test]
+    public void should_track_item_positions()
+    {
+        var builder = new ArrayBuilderWithItemPosition<int>(new[] { 10, 20, 30 });
+        var blob = builder.CreateManagedBlobAssetReference();
+        // After build, item position builders should have DataPosition set
+        var itemBuilder = builder[0];
+        Assert.GreaterOrEqual(itemBuilder.DataPosition, 0);
+        Assert.AreEqual(sizeof(int), itemBuilder.DataSize);
+    }
+}
+
+public class TestPtrBuilderVariants
+{
+    [Test]
+    public void should_build_ptr_with_default_value()
+    {
+        var builder = new PtrBuilderWithNewValue<int>();
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(0, blob.Value.Value);
+    }
+
+    [Test]
+    public void should_build_ptr_with_specified_value()
+    {
+        var builder = new PtrBuilderWithNewValue<int>(42);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value.Value);
+    }
+
+    [Test]
+    public void should_build_ptr_with_builder()
+    {
+        var valueBuilder = new ValueBuilder<int>(99);
+        var builder = new PtrBuilderWithNewValue<int>(valueBuilder);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(99, blob.Value.Value);
+    }
+
+    [Test]
+    public void should_expose_value_builder()
+    {
+        var valueBuilder = new ValueBuilder<int>(42);
+        var builder = new PtrBuilderWithNewValue<int>(valueBuilder);
+        Assert.IsNotNull(builder.ValueBuilder);
+    }
+
+    [Test]
+    public void should_build_ref_ptr()
+    {
+        var structBuilder = new ValueBuilder<int>(100);
+        var ptrBuilder = new PtrBuilderWithRefBuilder<int>(structBuilder);
+        // PtrBuilderWithRefBuilder references existing data position
+        var blob = ptrBuilder.CreateManagedBlobAssetReference();
+        // This tests the pointer resolution mechanics
+        Assert.IsNotNull(blob);
+    }
+
+    [Test]
+    public void should_expose_ref_value_builder()
+    {
+        var valueBuilder = new ValueBuilder<int>(42);
+        var builder = new PtrBuilderWithRefBuilder<int>(valueBuilder);
+        Assert.IsNotNull(builder.ValueBuilder);
+    }
+}
+
+public class TestValuePositionBuilder
+{
+    [Test]
+    public void should_store_data_position()
+    {
+        var builder = new ValuePositionBuilder();
+        builder.DataPosition = 16;
+        Assert.AreEqual(16, builder.DataPosition);
+    }
+
+    [Test]
+    public void should_store_data_size()
+    {
+        var builder = new ValuePositionBuilder();
+        builder.DataSize = 8;
+        Assert.AreEqual(8, builder.DataSize);
+    }
+
+    [Test]
+    public void should_store_patch_position()
+    {
+        var builder = new ValuePositionBuilder();
+        builder.PatchPosition = 32;
+        Assert.AreEqual(32, builder.PatchPosition);
+    }
+
+    [Test]
+    public void should_store_patch_size()
+    {
+        var builder = new ValuePositionBuilder();
+        builder.PatchSize = 16;
+        Assert.AreEqual(16, builder.PatchSize);
+    }
+
+    [Test]
+    public void should_throw_on_build()
+    {
+        var builder = new ValuePositionBuilder();
+        using var stream = new BlobMemoryStream();
+        Assert.Catch<NotSupportedException>(() => builder.Build(stream));
+    }
+
+    [Test]
+    public void should_work_as_generic_variant()
+    {
+        var builder = new ValuePositionBuilder<int>();
+        builder.DataPosition = 8;
+        Assert.AreEqual(8, builder.DataPosition);
+    }
+}
+
+public class TestUnsafeBlobStreamValue
+{
+    [Test]
+    public unsafe void should_read_value_from_stream()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 16;
+        int value = 42;
+        stream.Write((byte*)&value, sizeof(int), 4);
+
+        var unsafeValue = new UnsafeBlobStreamValue<int>(stream, 0);
+        Assert.AreEqual(42, unsafeValue.Value);
+    }
+
+    [Test]
+    public void should_throw_on_invalid_position()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 2;
+        Assert.Catch<ArgumentException>(() =>
+        {
+            var _ = new UnsafeBlobStreamValue<int>(stream, 0);
+        });
+    }
+
+    [Test]
+    public unsafe void should_write_via_ref()
+    {
+        using var stream = new BlobMemoryStream();
+        stream.Length = 16;
+        // Initialize with zero
+        int zero = 0;
+        stream.Write((byte*)&zero, sizeof(int), 4);
+
+        var unsafeValue = new UnsafeBlobStreamValue<int>(stream, 0);
+        unsafeValue.Value = 99;
+        Assert.AreEqual(99, unsafeValue.Value);
+    }
+}
+
+public class TestBuilderExtension
+{
+    [Test]
+    public void should_create_blob_bytes()
+    {
+        var builder = new ValueBuilder<int>(42);
+        var blob = builder.CreateBlob();
+        Assert.IsNotNull(blob);
+        Assert.GreaterOrEqual(blob.Length, sizeof(int));
+    }
+
+    [Test]
+    public void should_create_managed_blob_asset_reference_generic()
+    {
+        var builder = new ValueBuilder<int>(42);
+        using var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value);
+    }
+
+    [Test]
+    public void should_create_managed_blob_asset_reference_non_generic()
+    {
+        IBuilder builder = new ValueBuilder<int>(42);
+        using var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.GetValue<int>());
+    }
+
+    struct StructWithBlobPtrAny
+    {
+        public BlobPtrAny Ptr;
+        public int Value;
+    }
+
+    [Test]
+    public void should_set_pointer_any()
+    {
+        var builder = new StructBuilder<StructWithBlobPtrAny>();
+        builder.SetPointerAny(ref builder.Value.Ptr, 42);
+        builder.SetValue(ref builder.Value.Value, 100);
+        var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(42, blob.Value.Ptr.GetValue<int>());
+        Assert.AreEqual(100, blob.Value.Value);
+    }
+}
+
+public class TestManagedBlobAssetReferenceEdgeCases
+{
+    [Test]
+    public void should_expose_blob_bytes()
+    {
+        var builder = new ValueBuilder<int>(42);
+        using var blob = builder.CreateManagedBlobAssetReference();
+        Assert.IsNotNull(blob.Blob);
+        Assert.GreaterOrEqual(blob.Blob.Length, sizeof(int));
+    }
+
+    [Test]
+    public void should_expose_length()
+    {
+        var builder = new ValueBuilder<int>(42);
+        using var blob = builder.CreateManagedBlobAssetReference();
+        Assert.AreEqual(blob.Blob.Length, blob.Length);
+    }
+
+    [Test]
+    public void should_reject_empty_blob_generic()
+    {
+        Assert.Catch<ArgumentException>(() => new ManagedBlobAssetReference<int>(Array.Empty<byte>()));
+    }
+
+    [Test]
+    public void should_reject_empty_blob_non_generic()
+    {
+        Assert.Catch<ArgumentException>(() => new ManagedBlobAssetReference(Array.Empty<byte>()));
+    }
+
+    [Test]
+    public void should_not_throw_on_double_dispose_generic()
+    {
+        var builder = new ValueBuilder<int>(42);
+        var blob = builder.CreateManagedBlobAssetReference();
+        blob.Dispose();
+        blob.Dispose();
+    }
+
+    [Test]
+    public void should_not_throw_on_double_dispose_non_generic()
+    {
+        var bytes = new byte[] { 1, 2, 3, 4 };
+        var blob = new ManagedBlobAssetReference(bytes);
+        blob.Dispose();
+        blob.Dispose();
+    }
+
+    [Test]
+    public unsafe void should_expose_unsafe_ptr_generic()
+    {
+        var builder = new ValueBuilder<int>(42);
+        using var blob = builder.CreateManagedBlobAssetReference();
+        var ptr = blob.UnsafePtr;
+        Assert.AreEqual(42, *ptr);
+    }
+
+    [Test]
+    public unsafe void should_expose_stable_unsafe_ptr_generic()
+    {
+        var builder = new ValueBuilder<int>(42);
+        using var blob = builder.CreateManagedBlobAssetReference();
+        var ptr1 = blob.UnsafePtr;
+        var ptr2 = blob.UnsafePtr;
+        Assert.AreEqual((long)ptr1, (long)ptr2);
+    }
+
+    [Test]
+    public unsafe void non_generic_should_throw_when_too_small()
+    {
+        var bytes = new byte[] { 1, 2 };
+        using var blob = new ManagedBlobAssetReference(bytes);
+        Assert.Catch<ArgumentException>(() => blob.GetUnsafePtr<int>());
+    }
+
+    [Test]
+    public unsafe void non_generic_should_return_valid_value()
+    {
+        var builder = new ValueBuilder<int>(42);
+        var blobBytes = builder.CreateBlob();
+        using var blob = new ManagedBlobAssetReference(blobBytes);
+        ref var value = ref blob.GetValue<int>();
+        Assert.AreEqual(42, value);
+    }
+}
+
+public class TestTreeExtension
+{
+    sealed class SimpleNode
+    {
+        public int Value;
+        public List<SimpleNode> Children = new List<SimpleNode>();
+    }
+
+    [Test]
+    public void should_enumerate_self_and_descendants()
+    {
+        var root = new SimpleNode { Value = 1 };
+        var child1 = new SimpleNode { Value = 2 };
+        var child2 = new SimpleNode { Value = 3 };
+        var grandchild = new SimpleNode { Value = 4 };
+        root.Children.Add(child1);
+        root.Children.Add(child2);
+        child1.Children.Add(grandchild);
+
+        var all = root.SelfAndDescendants(n => n.Children).ToArray();
+        Assert.AreEqual(4, all.Length);
+        Assert.AreEqual(1, all[0].Value);
+        Assert.AreEqual(2, all[1].Value);
+        Assert.AreEqual(4, all[2].Value);
+        Assert.AreEqual(3, all[3].Value);
+    }
+
+    [Test]
+    public void should_handle_leaf_node()
+    {
+        var leaf = new SimpleNode { Value = 1 };
+        var all = leaf.SelfAndDescendants(n => n.Children).ToArray();
+        Assert.AreEqual(1, all.Length);
+        Assert.AreEqual(1, all[0].Value);
+    }
+}

--- a/src/Paradise.BLOB.Test/TestUtilities.cs
+++ b/src/Paradise.BLOB.Test/TestUtilities.cs
@@ -79,11 +79,13 @@ public class TestUtilities
     }
 
 
+    #pragma warning disable CS0169, CA1823
     struct Tuple<T1, T2>
     {
         private T1 _;
         private T2 __;
     }
+    #pragma warning restore CS0169, CA1823
 
     [Test]
     public void should_align_by_type()


### PR DESCRIPTION
Closes #18

## Summary
- Added 2 new test files with comprehensive coverage for all public Paradise.BLOB types
- `TestBlobDataTypes.cs`: Tests for BlobArray, BlobString, BlobNullTerminatedString, BlobPtr, BlobPtrAny, BlobArrayAny, BlobSortedArray edge cases, UnityBlobString
- `TestBuilderAndStream.cs`: Tests for BlobMemoryStream, BlobStreamExtension, ValueBuilder, StructBuilder, ArrayBuilder variants, PtrBuilder variants, ValuePositionBuilder, UnsafeBlobStreamValue, BuilderExtension, TreeExtension, ManagedBlobAssetReference edge cases
- Fixed pre-existing warnings-as-errors issues in existing test files (nullable annotations, CA1822/CA1852/CA2208 analyzer warnings)
- Total test count: 636 (all passing)

## Test plan
- [x] All 636 tests pass with `dotnet test -p:PublishAot=false`
- [x] Build passes with `TreatWarningsAsErrors=true`
- [x] No regressions in existing tests
- [x] Coverage touches all public types and meaningful edge cases