### PR TITLE
[dev] Fix OpenCara review findings from PR #24

### DIFF
--- a/src/Paradise.BT.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/Paradise.BT.Generators/AnalyzerReleases.Unshipped.md
@@ -3,3 +3,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 PBT0001 | Paradise.BT.Generators | Error | Struct with [Builder] is missing [Guid] attribute
+PBT0002 | Paradise.BT.Generators | Warning | Struct with [Builder] contains managed references

--- a/src/Paradise.BT.Generators/BTreeNodeGenerator.cs
+++ b/src/Paradise.BT.Generators/BTreeNodeGenerator.cs
@@ -20,6 +20,15 @@ public sealed class BTreeNodeGenerator : IIncrementalGenerator
         isEnabledByDefault: true
     );
 
+    private static readonly DiagnosticDescriptor s_notUnmanagedDiagnostic = new(
+        id: "PBT0002",
+        title: "Builder struct is not unmanaged",
+        messageFormat: "Struct '{0}' has [Builder] but contains managed references and cannot be used as an INodeData builder",
+        category: "Paradise.BT.Generators",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true
+    );
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var provider = context.SyntaxProvider.CreateSyntaxProvider(
@@ -41,7 +50,14 @@ public sealed class BTreeNodeGenerator : IIncrementalGenerator
             }
 
             if (!info.IsUnmanaged)
+            {
+                spc.ReportDiagnostic(Diagnostic.Create(
+                    s_notUnmanagedDiagnostic,
+                    info.Location,
+                    info.StructName
+                ));
                 return;
+            }
 
             var source = GenerateWrapper(info);
             spc.AddSource($"{info.GeneratedClassName}.g.cs", source);
@@ -50,9 +66,12 @@ public sealed class BTreeNodeGenerator : IIncrementalGenerator
 
     private static NodeInfo? GetNodeInfo(GeneratorSyntaxContext ctx, System.Threading.CancellationToken ct)
     {
+        ct.ThrowIfCancellationRequested();
         var structDecl = (StructDeclarationSyntax)ctx.Node;
         if (ctx.SemanticModel.GetDeclaredSymbol(structDecl, ct) is not INamedTypeSymbol structSymbol)
             return null;
+
+        ct.ThrowIfCancellationRequested();
 
         // Get [Builder] attribute data
         AttributeData? builderAttr = null;
@@ -284,7 +303,7 @@ public sealed class BTreeNodeGenerator : IIncrementalGenerator
         return char.ToLowerInvariant(name[0]) + name.Substring(1);
     }
 
-    private readonly struct NodeInfo
+    private readonly struct NodeInfo : System.IEquatable<NodeInfo>
     {
         public readonly string StructName;
         public readonly string FullyQualifiedStructName;
@@ -317,9 +336,33 @@ public sealed class BTreeNodeGenerator : IIncrementalGenerator
             Fields = fields;
             Location = location;
         }
+
+        public bool Equals(NodeInfo other) =>
+            StructName == other.StructName
+            && FullyQualifiedStructName == other.FullyQualifiedStructName
+            && GeneratedClassName == other.GeneratedClassName
+            && Namespace == other.Namespace
+            && Cardinality == other.Cardinality
+            && HasGuid == other.HasGuid
+            && IsUnmanaged == other.IsUnmanaged
+            && Fields.SequenceEqual(other.Fields);
+
+        public override bool Equals(object? obj) => obj is NodeInfo other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = FullyQualifiedStructName.GetHashCode();
+                hash = hash * 31 + Cardinality;
+                hash = hash * 31 + (HasGuid ? 1 : 0);
+                hash = hash * 31 + (IsUnmanaged ? 1 : 0);
+                return hash;
+            }
+        }
     }
 
-    private readonly struct FieldInfo
+    private readonly struct FieldInfo : System.IEquatable<FieldInfo>
     {
         public readonly string Name;
         public readonly string TypeName;
@@ -329,5 +372,11 @@ public sealed class BTreeNodeGenerator : IIncrementalGenerator
             Name = name;
             TypeName = typeName;
         }
+
+        public bool Equals(FieldInfo other) => Name == other.Name && TypeName == other.TypeName;
+
+        public override bool Equals(object? obj) => obj is FieldInfo other && Equals(other);
+
+        public override int GetHashCode() => Name.GetHashCode() ^ TypeName.GetHashCode();
     }
 }

--- a/src/Paradise.BT.Sample/CheckCondition.cs
+++ b/src/Paradise.BT.Sample/CheckCondition.cs
@@ -1,4 +1,5 @@
 using Paradise.BT;
+using Paradise.BT.Sample;
 using Paradise.BT.Builder;
 
 public sealed class CheckCondition : BTreeNode

--- a/src/Paradise.BT.Sample/Delay.cs
+++ b/src/Paradise.BT.Sample/Delay.cs
@@ -1,4 +1,5 @@
 using Paradise.BT;
+using Paradise.BT.Sample;
 using Paradise.BT.Builder;
 
 public sealed class Delay : BTreeNode

--- a/src/Paradise.BT.Sample/Nodes.cs
+++ b/src/Paradise.BT.Sample/Nodes.cs
@@ -1,0 +1,50 @@
+using System.Runtime.InteropServices;
+using Paradise.BT;
+
+namespace Paradise.BT.Sample;
+
+[Guid("B0E631D3-64E8-467F-B39A-1E4AF41E6A66")]
+public struct DelegateActionNode : INodeData
+{
+    private readonly Func<IBlackboard, int, NodeState> _action;
+
+    public DelegateActionNode(Func<IBlackboard, int, NodeState> action)
+    {
+        _action = action ?? throw new ArgumentNullException(nameof(action));
+    }
+
+    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+        where TNodeBlob : struct, INodeBlob
+        where TBlackboard : struct, IBlackboard
+        => _action(bb, index);
+}
+
+[Guid("55BF6D71-62B0-4AB8-9B51-B0B58B7AC76A")]
+public struct DelegateConditionNode : INodeData
+{
+    private readonly Func<IBlackboard, int, bool> _predicate;
+
+    public DelegateConditionNode(Func<IBlackboard, int, bool> predicate)
+    {
+        _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+    }
+
+    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+        where TNodeBlob : struct, INodeBlob
+        where TBlackboard : struct, IBlackboard
+        => _predicate(bb, index).ToNodeState();
+}
+
+[Guid("2F6009D3-1314-42E6-8E52-4AEB7CDDB4CD")]
+public struct DelayTimerNode : INodeData
+{
+    public float TimerSeconds;
+
+    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+        where TNodeBlob : struct, INodeBlob
+        where TBlackboard : struct, IBlackboard
+    {
+        TimerSeconds -= bb.GetData<BehaviorTreeTickDeltaTime>().Value;
+        return TimerSeconds <= 0f ? NodeState.Success : NodeState.Running;
+    }
+}

--- a/src/Paradise.BT.Sample/RunAction.cs
+++ b/src/Paradise.BT.Sample/RunAction.cs
@@ -1,4 +1,5 @@
 using Paradise.BT;
+using Paradise.BT.Sample;
 using Paradise.BT.Builder;
 
 public sealed class RunAction : BTreeNode

--- a/src/Paradise.BT.Test/TestNodes.cs
+++ b/src/Paradise.BT.Test/TestNodes.cs
@@ -1,0 +1,67 @@
+using System.Runtime.InteropServices;
+
+namespace Paradise.BT.Test;
+
+[Guid("B0E631D3-64E8-467F-B39A-1E4AF41E6A66")]
+public struct DelegateActionNode : INodeData
+{
+    private readonly Func<IBlackboard, int, NodeState> _action;
+
+    public DelegateActionNode(Func<IBlackboard, int, NodeState> action)
+    {
+        _action = action ?? throw new ArgumentNullException(nameof(action));
+    }
+
+    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+        where TNodeBlob : struct, INodeBlob
+        where TBlackboard : struct, IBlackboard
+        => _action(bb, index);
+}
+
+[Guid("55BF6D71-62B0-4AB8-9B51-B0B58B7AC76A")]
+public struct DelegateConditionNode : INodeData
+{
+    private readonly Func<IBlackboard, int, bool> _predicate;
+
+    public DelegateConditionNode(Func<IBlackboard, int, bool> predicate)
+    {
+        _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+    }
+
+    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+        where TNodeBlob : struct, INodeBlob
+        where TBlackboard : struct, IBlackboard
+        => _predicate(bb, index).ToNodeState();
+}
+
+[Guid("2F6009D3-1314-42E6-8E52-4AEB7CDDB4CD")]
+public struct DelayTimerNode : INodeData
+{
+    public float TimerSeconds;
+
+    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+        where TNodeBlob : struct, INodeBlob
+        where TBlackboard : struct, IBlackboard
+    {
+        TimerSeconds -= bb.GetData<BehaviorTreeTickDeltaTime>().Value;
+        return TimerSeconds <= 0f ? NodeState.Success : NodeState.Running;
+    }
+}
+
+public static class TestBehaviorNodes
+{
+    public static BehaviorNodeDefinition Delay(float seconds)
+        => BehaviorNodes.Node(new DelayTimerNode { TimerSeconds = seconds });
+
+    public static BehaviorNodeDefinition Action(Func<IBlackboard, NodeState> action)
+        => Action((bb, _) => action(bb));
+
+    public static BehaviorNodeDefinition Action(Func<IBlackboard, int, NodeState> action)
+        => BehaviorNodes.Node(new DelegateActionNode(action));
+
+    public static BehaviorNodeDefinition Condition(Func<IBlackboard, bool> predicate)
+        => Condition((bb, _) => predicate(bb));
+
+    public static BehaviorNodeDefinition Condition(Func<IBlackboard, int, bool> predicate)
+        => BehaviorNodes.Node(new DelegateConditionNode(predicate));
+}

--- a/src/Paradise.BT/Paradise.BT.csproj
+++ b/src/Paradise.BT/Paradise.BT.csproj
@@ -32,7 +32,7 @@
       <Pack>true</Pack>
       <PackagePath>README.md</PackagePath>
     </None>
-    <None Include="$(OutputPath)\..\..\..\Paradise.BT.Generators\$(Configuration)\netstandard2.0\Paradise.BT.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(MSBuildProjectDirectory)\..\Paradise.BT.Generators\bin\$(Configuration)\netstandard2.0\Paradise.BT.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Fix NuGet packaging path for generator DLL (`$(OutputPath)` → `$(MSBuildProjectDirectory)` with correct `bin\` segment)
- Add `PBT0002` diagnostic warning when `[Builder]` is on a non-unmanaged struct (was silently skipped)
- Pass `CancellationToken` through source generator for IDE responsiveness
- Implement `IEquatable<T>` on `NodeInfo`/`FieldInfo` for proper incremental generator caching
- Add missing node struct definitions (`DelegateActionNode`, `DelegateConditionNode`, `DelayTimerNode`) to sample and test projects
- Fix broken test build from accidental node deletion in workflow fix commit

## Test plan
- [x] All 142 tests pass
- [x] Generator builds clean
- [x] Library builds clean
- [x] Sample app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)