### PR TITLE
[dev] Add Roslyn analyzer for duplicate Guid on INodeData structs

### DIFF
--- a/ParadiseEngine.slnx
+++ b/ParadiseEngine.slnx
@@ -3,6 +3,7 @@
   <Project Path="src/Paradise.BT.Generators/Paradise.BT.Generators.csproj" />
   <Project Path="src/Paradise.BT.Sample/Paradise.BT.Sample.csproj" />
   <Project Path="src/Paradise.BT.Test/Paradise.BT.Test.csproj" />
+  <Project Path="src/Paradise.BT.Generators.Test/Paradise.BT.Generators.Test.csproj" />
   <Project Path="src/Paradise.BLOB/Paradise.BLOB.csproj" />
   <Project Path="src/Paradise.BLOB.Test/Paradise.BLOB.Test.csproj" />
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,6 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
     <PackageVersion Include="TUnit" Version="1.11.16" />
   </ItemGroup>
 </Project>

--- a/src/Paradise.BT.Generators.Test/DuplicateGuidAnalyzerTests.cs
+++ b/src/Paradise.BT.Generators.Test/DuplicateGuidAnalyzerTests.cs
@@ -1,0 +1,222 @@
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Paradise.BT.Generators;
+
+namespace Paradise.BT.Generators.Test;
+
+public class DuplicateGuidAnalyzerTests
+{
+    private static DiagnosticResult Diagnostic(params object[] arguments)
+    {
+        return CSharpAnalyzerVerifier<DuplicateGuidAnalyzer, DefaultVerifier>
+            .Diagnostic(DuplicateGuidAnalyzer.s_duplicateGuidDiagnostic)
+            .WithArguments(arguments);
+    }
+
+    [Test]
+    public async Task DuplicateGuids_OnINodeDataStructs_ReportsError()
+    {
+        const string testCode = """
+            using System.Runtime.InteropServices;
+
+            namespace Paradise.BT
+            {
+                public enum NodeState { Success, Failure, Running }
+                public interface INodeBlob { }
+                public interface IBlackboard { }
+                public interface INodeData
+                {
+                    NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard;
+                }
+
+                [Guid("11111111-1111-1111-1111-111111111111")]
+                public struct NodeA : INodeData
+                {
+                    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard
+                    {
+                        return NodeState.Success;
+                    }
+                }
+
+                [Guid("11111111-1111-1111-1111-111111111111")]
+                public struct NodeB : INodeData
+                {
+                    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard
+                    {
+                        return NodeState.Success;
+                    }
+                }
+            }
+            """;
+
+        var test = new CSharpAnalyzerTest<DuplicateGuidAnalyzer, DefaultVerifier>
+        {
+            TestCode = testCode,
+        };
+
+        test.ExpectedDiagnostics.Add(
+            Diagnostic("11111111-1111-1111-1111-111111111111", "Paradise.BT.NodeA", "Paradise.BT.NodeB")
+                .WithSpan(16, 19, 16, 24));
+        test.ExpectedDiagnostics.Add(
+            Diagnostic("11111111-1111-1111-1111-111111111111", "Paradise.BT.NodeB", "Paradise.BT.NodeA")
+                .WithSpan(27, 19, 27, 24));
+
+        await test.RunAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task UniqueGuids_OnINodeDataStructs_NoDiagnostic()
+    {
+        const string testCode = """
+            using System.Runtime.InteropServices;
+
+            namespace Paradise.BT
+            {
+                public enum NodeState { Success, Failure, Running }
+                public interface INodeBlob { }
+                public interface IBlackboard { }
+                public interface INodeData
+                {
+                    NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard;
+                }
+
+                [Guid("11111111-1111-1111-1111-111111111111")]
+                public struct NodeA : INodeData
+                {
+                    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard
+                    {
+                        return NodeState.Success;
+                    }
+                }
+
+                [Guid("22222222-2222-2222-2222-222222222222")]
+                public struct NodeB : INodeData
+                {
+                    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard
+                    {
+                        return NodeState.Success;
+                    }
+                }
+            }
+            """;
+
+        var test = new CSharpAnalyzerTest<DuplicateGuidAnalyzer, DefaultVerifier>
+        {
+            TestCode = testCode,
+        };
+
+        await test.RunAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task DuplicateGuids_OnNonINodeDataStructs_NoDiagnostic()
+    {
+        const string testCode = """
+            using System.Runtime.InteropServices;
+
+            namespace Paradise.BT
+            {
+                public enum NodeState { Success, Failure, Running }
+                public interface INodeBlob { }
+                public interface IBlackboard { }
+                public interface INodeData
+                {
+                    NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard;
+                }
+            }
+
+            namespace Other
+            {
+                [Guid("11111111-1111-1111-1111-111111111111")]
+                public struct NotANode
+                {
+                    public int Value;
+                }
+
+                [Guid("11111111-1111-1111-1111-111111111111")]
+                public struct AlsoNotANode
+                {
+                    public int Value;
+                }
+            }
+            """;
+
+        var test = new CSharpAnalyzerTest<DuplicateGuidAnalyzer, DefaultVerifier>
+        {
+            TestCode = testCode,
+        };
+
+        await test.RunAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task DuplicateGuids_CaseInsensitive_ReportsError()
+    {
+        const string testCode = """
+            using System.Runtime.InteropServices;
+
+            namespace Paradise.BT
+            {
+                public enum NodeState { Success, Failure, Running }
+                public interface INodeBlob { }
+                public interface IBlackboard { }
+                public interface INodeData
+                {
+                    NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard;
+                }
+
+                [Guid("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")]
+                public struct NodeA : INodeData
+                {
+                    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard
+                    {
+                        return NodeState.Success;
+                    }
+                }
+
+                [Guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")]
+                public struct NodeB : INodeData
+                {
+                    public NodeState Tick<TNodeBlob, TBlackboard>(int index, ref TNodeBlob blob, ref TBlackboard bb)
+                        where TNodeBlob : struct, INodeBlob
+                        where TBlackboard : struct, IBlackboard
+                    {
+                        return NodeState.Success;
+                    }
+                }
+            }
+            """;
+
+        var test = new CSharpAnalyzerTest<DuplicateGuidAnalyzer, DefaultVerifier>
+        {
+            TestCode = testCode,
+        };
+
+        test.ExpectedDiagnostics.Add(
+            Diagnostic("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", "Paradise.BT.NodeA", "Paradise.BT.NodeB")
+                .WithSpan(16, 19, 16, 24));
+        test.ExpectedDiagnostics.Add(
+            Diagnostic("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "Paradise.BT.NodeB", "Paradise.BT.NodeA")
+                .WithSpan(27, 19, 27, 24));
+
+        await test.RunAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Paradise.BT.Generators.Test/Paradise.BT.Generators.Test.csproj
+++ b/src/Paradise.BT.Generators.Test/Paradise.BT.Generators.Test.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <PublishAot>true</PublishAot>
+    <NoWarn>$(NoWarn);NU1701;NETSDK1188</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Paradise.BT.Generators/Paradise.BT.Generators.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paradise.BT.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/Paradise.BT.Generators/AnalyzerReleases.Unshipped.md
@@ -4,3 +4,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 PBT0001 | Paradise.BT.Generators | Error | Struct with [Builder] is missing [Guid] attribute
 PBT0002 | Paradise.BT.Generators | Warning | Struct with [Builder] contains managed references
+PBT0003 | Paradise.BT.Design | Error | Duplicate [Guid] on INodeData structs

--- a/src/Paradise.BT.Generators/DuplicateGuidAnalyzer.cs
+++ b/src/Paradise.BT.Generators/DuplicateGuidAnalyzer.cs
@@ -1,0 +1,116 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Paradise.BT.Generators;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DuplicateGuidAnalyzer : DiagnosticAnalyzer
+{
+    private const string INodeDataFullName = "Paradise.BT.INodeData";
+    private const string GuidAttributeFullName = "System.Runtime.InteropServices.GuidAttribute";
+
+    internal static readonly DiagnosticDescriptor s_duplicateGuidDiagnostic = new(
+        id: "PBT0003",
+        title: "Duplicate Guid on INodeData struct",
+        messageFormat: "Duplicate Guid \"{0}\" on INodeData struct '{1}' — also used by '{2}'. Each node type must have a unique Guid.",
+        category: "Paradise.BT.Design",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        customTags: new[] { WellKnownDiagnosticTags.CompilationEnd }
+    );
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(s_duplicateGuidDiagnostic);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var nodeDataInterface = compilationContext.Compilation.GetTypeByMetadataName(INodeDataFullName);
+            if (nodeDataInterface is null)
+                return;
+
+            var guidsByValue = new ConcurrentDictionary<string, ConcurrentBag<(INamedTypeSymbol Symbol, Location Location, string GuidValue)>>(
+                StringComparer.OrdinalIgnoreCase
+            );
+
+            compilationContext.RegisterSymbolAction(symbolContext =>
+            {
+                var namedType = (INamedTypeSymbol)symbolContext.Symbol;
+
+                if (namedType.TypeKind != TypeKind.Struct)
+                    return;
+
+                if (!ImplementsInterface(namedType, nodeDataInterface))
+                    return;
+
+                string? guidValue = null;
+                foreach (var attr in namedType.GetAttributes())
+                {
+                    if (attr.AttributeClass?.ToDisplayString() == GuidAttributeFullName
+                        && attr.ConstructorArguments.Length == 1
+                        && attr.ConstructorArguments[0].Value is string g)
+                    {
+                        guidValue = g;
+                        break;
+                    }
+                }
+
+                if (guidValue is null)
+                    return;
+
+                var location = namedType.Locations.Length > 0
+                    ? namedType.Locations[0]
+                    : Location.None;
+
+                var bag = guidsByValue.GetOrAdd(guidValue, _ => new ConcurrentBag<(INamedTypeSymbol, Location, string)>());
+                bag.Add((namedType, location, guidValue));
+            }, SymbolKind.NamedType);
+
+            compilationContext.RegisterCompilationEndAction(endContext =>
+            {
+                foreach (var kvp in guidsByValue)
+                {
+                    var entries = kvp.Value.ToArray();
+                    if (entries.Length < 2)
+                        continue;
+
+                    for (int i = 0; i < entries.Length; i++)
+                    {
+                        // Build list of other type names
+                        var otherNames = new System.Collections.Generic.List<string>();
+                        for (int j = 0; j < entries.Length; j++)
+                        {
+                            if (j != i)
+                                otherNames.Add(entries[j].Symbol.ToDisplayString());
+                        }
+                        string otherNamesStr = string.Join(", ", otherNames);
+
+                        endContext.ReportDiagnostic(Diagnostic.Create(
+                            s_duplicateGuidDiagnostic,
+                            entries[i].Location,
+                            entries[i].GuidValue,
+                            entries[i].Symbol.ToDisplayString(),
+                            otherNamesStr
+                        ));
+                    }
+                }
+            });
+        });
+    }
+
+    private static bool ImplementsInterface(INamedTypeSymbol type, INamedTypeSymbol interfaceSymbol)
+    {
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(iface, interfaceSymbol))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/Paradise.BT.Generators/Paradise.BT.Generators.csproj
+++ b/src/Paradise.BT.Generators/Paradise.BT.Generators.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Paradise.BT.Generators.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #26

## Summary
- Add `DuplicateGuidAnalyzer` (PBT0003) to `Paradise.BT.Generators` that detects duplicate `[Guid]` values across `INodeData` structs at compile time
- Uses `DiagnosticAnalyzer` with `CompilationStart`/`CompilationEnd` pattern for cross-file, case-insensitive GUID duplicate detection
- Add new `Paradise.BT.Generators.Test` project with 4 analyzer unit tests (duplicate GUIDs, unique GUIDs, non-INodeData structs, case-insensitive matching)
- Note: Uses PBT0003 (not PBT0002 as originally specified in the issue) because PBT0002 is already used for the "unmanaged struct" diagnostic

## Test plan
- [x] Duplicate `[Guid]` on `INodeData` structs produces compile-time error PBT0003
- [x] Unique GUIDs produce no diagnostic
- [x] Non-`INodeData` structs with duplicate GUIDs are not flagged
- [x] Case-insensitive GUID comparison works correctly
- [x] Full solution build passes with `TreatWarningsAsErrors=true`
- [x] All 782 tests pass (including 4 new analyzer tests)