### PR TITLE
[dev] CI: run dotnet-test on PRs, add concurrency group

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -3,6 +3,12 @@ name: .NET Test
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:


### PR DESCRIPTION
Closes #30

## Summary
- Add `pull_request` trigger (`branches: [main]`) alongside the existing `push` trigger in `.github/workflows/dotnet-test.yml`, so PRs to main are gated by build+test.
- Add a `concurrency:` block keyed on `github.event.pull_request.number || github.sha`, with `cancel-in-progress: true` only on `pull_request` events. This cancels superseded PR runs but never preempts main-branch runs (each main push gets a unique SHA-keyed group).

## Deviation from issue spec
The issue asked to replace `--solution ParadiseEngine.slnx` with a positional solution path because `--solution` was presumed invalid for `dotnet test`. **On the SDK pinned by `global.json` (10.0.200), the opposite is true**:

- Positional form is rejected: `Specifying a solution for 'dotnet test' should be via '--solution'.`
- `dotnet test --help` documents `--solution <SOLUTION_PATH>` as the official flag.
- `--output <Detailed|Normal>` is also a documented test-output-verbosity flag (not the binary output directory, as the spec assumed).

The existing command is therefore correct for this SDK, and I left it unchanged. The `dotnet test` CLI described in the issue belongs to an older VSTest-based path; Microsoft.Testing.Platform (what TUnit uses, opted in via `global.json`) exposes the new flag set.

## Pre-existing test failures (not caused by this PR)
When running locally, 4 tests in `Paradise.BT.Generators.Test` fail with `AOT compilation detected. Dynamic code generation is not supported.`:
- `DuplicateGuids_OnNonINodeDataStructs_NoDiagnostic`
- `UniqueGuids_OnINodeDataStructs_NoDiagnostic`
- `DuplicateGuids_OnINodeDataStructs_ReportsError`
- `DuplicateGuids_CaseInsensitive_ReportsError`

These reproduce on clean `main` (same 4 failures, 780 passing). They are unrelated to this CI change and should be tracked as a separate issue. The CI workflow may currently fail on this PR because of them — if so, that is orthogonal to the trigger/concurrency change.

## Test plan
- [ ] This PR shows the **.NET Test** workflow running as a check against the PR head SHA.
- [ ] Workflow build step succeeds with `-p:TreatWarningsAsErrors=true`.
- [ ] `dotnet test` step actually executes tests (verify via log: TUnit banner, test module run lines for `Paradise.BLOB.Test`, `Paradise.BT.Test`, `Paradise.BT.Generators.Test`).
- [ ] A second push to this branch cancels the in-flight run (concurrency group sanity check).