### PR TITLE
[dev] Fix CI: remove PublishAot=true from test csprojs

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -29,4 +29,4 @@ jobs:
         run: dotnet build ParadiseEngine.slnx --no-restore -p:TreatWarningsAsErrors=true
 
       - name: Test
-        run: dotnet test --solution ParadiseEngine.slnx --no-build -p:PublishAot=false --output normal
+        run: dotnet test --solution ParadiseEngine.slnx --no-build --output normal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ dotnet test src/Paradise.BT.Test/Paradise.BT.Test.csproj --output normal
 dotnet run --project src/Paradise.BT.Sample/Paradise.BT.Sample.csproj
 ```
 
-AOT compatibility of the libraries is verified via `Paradise.BT.Sample`, which sets `<PublishAot>true</PublishAot>`. Test projects do not enable AOT so the analyzer-testing harness can use `Reflection.Emit`.
+AOT compatibility of tree construction and ticking is verified via `Paradise.BT.Sample`, which sets `<PublishAot>true</PublishAot>`. Test projects do not enable AOT so the analyzer-testing harness can use `Reflection.Emit`. The `Paradise.BT` serialization surface (`Serialize`/`Deserialize`) and `Paradise.BLOB`'s `ManagedBlobAssetReference` are not currently covered by an AOT build; adding a dedicated AOT publish-and-run CI job for those paths is a known follow-up.
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 dotnet build --solution ParadiseEngine.slnx
 
 # Run all tests
-dotnet test --solution ParadiseEngine.slnx -p:PublishAot=false --output normal
+dotnet test --solution ParadiseEngine.slnx --output normal
 
 # Build/test a single project
 dotnet build src/Paradise.BT/Paradise.BT.csproj
-dotnet test src/Paradise.BT.Test/Paradise.BT.Test.csproj -p:PublishAot=false --output normal
+dotnet test src/Paradise.BT.Test/Paradise.BT.Test.csproj --output normal
 
 # Run the sample app
 dotnet run --project src/Paradise.BT.Sample/Paradise.BT.Sample.csproj
 ```
 
-The `-p:PublishAot=false` flag is required for tests because test projects enable AOT but TUnit needs it disabled at test time.
+AOT compatibility of the libraries is verified via `Paradise.BT.Sample`, which sets `<PublishAot>true</PublishAot>`. Test projects do not enable AOT so the analyzer-testing harness can use `Reflection.Emit`.
 
 ## Project Overview
 

--- a/src/Paradise.BLOB.Test/Paradise.BLOB.Test.csproj
+++ b/src/Paradise.BLOB.Test/Paradise.BLOB.Test.csproj
@@ -6,7 +6,6 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <PublishAot>true</PublishAot>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Paradise.BT.Generators.Test/Paradise.BT.Generators.Test.csproj
+++ b/src/Paradise.BT.Generators.Test/Paradise.BT.Generators.Test.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <PublishAot>true</PublishAot>
     <NoWarn>$(NoWarn);NU1701;NETSDK1188</NoWarn>
   </PropertyGroup>
 

--- a/src/Paradise.BT.Test/Paradise.BT.Test.csproj
+++ b/src/Paradise.BT.Test/Paradise.BT.Test.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #33

## Summary
- Remove `<PublishAot>true</PublishAot>` from `Paradise.BLOB.Test`, `Paradise.BT.Test`, and `Paradise.BT.Generators.Test`.
- Keep `<PublishAot>true</PublishAot>` in `Paradise.BT.Sample` — intentional AOT-verified consumer.
- Drop `-p:PublishAot=false` from `.github/workflows/dotnet-test.yml` (nothing left to override).
- Update `CLAUDE.md` "Build and Test Commands" section to match the simplified invocation.

## Root cause
`<PublishAot>true</PublishAot>` causes the SDK to bake `System.Reflection.Emit.DynamicCodeSupported=false` into `*.runtimeconfig.json` at build time. CI's `-p:PublishAot=false` was combined with `--no-build`, so the runtime config was never regenerated and the test binary still ran with dynamic code disabled. `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` in `Paradise.BT.Generators.Test` uses `Reflection.Emit` to compile test inputs → `PlatformNotSupportedException` at runtime.

## CLAUDE.md changes
- Replaced the two `dotnet test … -p:PublishAot=false --output normal` examples with the simplified form.
- Replaced the trailing "`-p:PublishAot=false` flag is required …" paragraph with a short note that AOT compatibility is verified via `Paradise.BT.Sample` and that test projects no longer enable AOT (so the analyzer-testing harness can use `Reflection.Emit`).

No other edits to `CLAUDE.md`.

## AOT coverage impact
- Before: test csprojs were built under AOT constraints, giving incidental trim/warning coverage on test-only code paths.
- After: tests are built as regular managed binaries. `Paradise.BT.Sample` remains the sole AOT-verified consumer.
- The core libraries (`Paradise.BLOB`, `Paradise.BT`, `Paradise.BT.Builder`, `Paradise.BT.Nodes`, `Paradise.BT.Generators`) are still exercised under AOT when consumed by `Paradise.BT.Sample`.
- Follow-up suggestion (not in scope for this PR): add a dedicated CI job that `dotnet publish`es `Paradise.BT.Sample` with AOT and runs the resulting native binary, so AOT regressions get caught at CI time rather than only via manual publish.

## Test plan
- [x] All 784 tests pass locally via `dotnet test --solution ParadiseEngine.slnx --no-build --output normal` in this worktree.
- [x] `dotnet build ParadiseEngine.slnx -p:TreatWarningsAsErrors=true` succeeds (0 errors).
- [ ] CI on this PR (`.NET Test`) is green — first PR to exercise the new `pull_request` trigger from #32.