### PR TITLE
Port ParadiseECS PR #56 job system

### DIFF
--- a/ParadiseEngine.slnx
+++ b/ParadiseEngine.slnx
@@ -16,6 +16,7 @@
     <Project Path="src/Paradise.BT.Nodes/Paradise.BT.Nodes.csproj" />
     <Project Path="src/Paradise.BT/Paradise.BT.csproj" />
     <Project Path="src/Paradise.ECS.Concurrent/Paradise.ECS.Concurrent.csproj" />
+    <Project Path="src/Paradise.ECS.Jobs/Paradise.ECS.Jobs.csproj" />
     <Project Path="src/Paradise.ECS.Tag/Paradise.ECS.Tag.csproj" />
     <Project Path="src/Paradise.ECS/Paradise.ECS.csproj" />
   </Folder>
@@ -25,6 +26,7 @@
     <Project Path="src/Paradise.BT.Test/Paradise.BT.Test.csproj" />
     <Project Path="src/Paradise.ECS.Concurrent.Test/Paradise.ECS.Concurrent.Test.csproj" />
     <Project Path="src/Paradise.ECS.CoyoteTest/Paradise.ECS.CoyoteTest.csproj" />
+    <Project Path="src/Paradise.ECS.Jobs.Test/Paradise.ECS.Jobs.Test.csproj" />
     <Project Path="src/Paradise.ECS.Generators.Test/Paradise.ECS.Generators.Test.csproj" />
     <Project Path="src/Paradise.ECS.Test/Paradise.ECS.Test.csproj" />
   </Folder>

--- a/src/Paradise.ECS.Benchmarks/BenchmarkComponents.cs
+++ b/src/Paradise.ECS.Benchmarks/BenchmarkComponents.cs
@@ -1,0 +1,13 @@
+namespace Paradise.ECS.Benchmarks;
+
+[Component("EAEEB062-5E8F-4B6A-B3B6-1F60393B3547", Id = 0)]
+public partial struct BenchPosition
+{
+    public float X, Y, Z;
+}
+
+[Component("897422E5-00F8-47FE-BB9B-9035DD17E0A3", Id = 1)]
+public partial struct BenchVelocity
+{
+    public float X, Y, Z;
+}

--- a/src/Paradise.ECS.Benchmarks/BenchmarkSystems.cs
+++ b/src/Paradise.ECS.Benchmarks/BenchmarkSystems.cs
@@ -1,0 +1,20 @@
+namespace Paradise.ECS.Benchmarks;
+
+/// <summary>
+/// Benchmark system: adds velocity to position per entity.
+/// </summary>
+public ref partial struct BenchMovementSystem : IEntitySystem
+{
+    public ref BenchPosition Position;
+    public ref readonly BenchVelocity Velocity;
+
+    public void Execute()
+    {
+        Position = new BenchPosition
+        {
+            X = Position.X + Velocity.X,
+            Y = Position.Y + Velocity.Y,
+            Z = Position.Z + Velocity.Z
+        };
+    }
+}

--- a/src/Paradise.ECS.Benchmarks/Paradise.ECS.Benchmarks.csproj
+++ b/src/Paradise.ECS.Benchmarks/Paradise.ECS.Benchmarks.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Paradise.ECS\Paradise.ECS.csproj" />
+    <ProjectReference Include="..\Paradise.ECS.Jobs\Paradise.ECS.Jobs.csproj" />
     <ProjectReference Include="..\Paradise.ECS.Generators\Paradise.ECS.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/src/Paradise.ECS.Benchmarks/RawPoolBenchmarks.cs
+++ b/src/Paradise.ECS.Benchmarks/RawPoolBenchmarks.cs
@@ -1,0 +1,76 @@
+using BenchmarkDotNet.Attributes;
+using Paradise.ECS;
+
+namespace Paradise.ECS.Benchmarks;
+
+/// <summary>
+/// Direct comparison of raw pool execution strategies.
+/// </summary>
+[MemoryDiagnoser]
+public class RawPoolBenchmarks
+{
+    [Params(10, 100, 1000)]
+    public int ItemCount { get; set; }
+
+    private JobWorkerPool _jobPool = null!;
+    private WorkStealingPool _wsPool = null!;
+    private double[] _results = null!;
+    private List<SimWorkItem> _items = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _jobPool = new JobWorkerPool();
+        _wsPool = new WorkStealingPool();
+        _results = new double[ItemCount];
+        _items = new List<SimWorkItem>(ItemCount);
+        for (int i = 0; i < ItemCount; i++)
+            _items.Add(new SimWorkItem(i, _results));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _jobPool.Dispose();
+        _wsPool.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void Sequential()
+    {
+        for (int i = 0; i < ItemCount; i++)
+            SimWorkItem.SimulateWork(i, _results);
+    }
+
+    [Benchmark]
+    public void ParallelFor()
+    {
+        Parallel.For(0, ItemCount, i => SimWorkItem.SimulateWork(i, _results));
+    }
+
+    [Benchmark]
+    public void JobPool()
+    {
+        _jobPool.ExecuteWork(_items);
+    }
+
+    [Benchmark]
+    public void WorkStealing()
+    {
+        _wsPool.ExecuteWork(_items);
+    }
+
+    internal readonly struct SimWorkItem(int index, double[] results) : IWorkItem
+    {
+        public void Invoke() => SimulateWork(index, results);
+
+        public static void SimulateWork(int index, double[] results)
+        {
+            // ~100 iterations of trig to simulate meaningful per-item work
+            double sum = 0;
+            for (int j = 0; j < 100; j++)
+                sum += Math.Sin(index + j);
+            results[index] = sum;
+        }
+    }
+}

--- a/src/Paradise.ECS.Benchmarks/WaveSchedulerBenchmarks.cs
+++ b/src/Paradise.ECS.Benchmarks/WaveSchedulerBenchmarks.cs
@@ -1,0 +1,80 @@
+using BenchmarkDotNet.Attributes;
+using Paradise.ECS;
+
+namespace Paradise.ECS.Benchmarks;
+
+/// <summary>
+/// End-to-end benchmark comparing wave scheduler strategies:
+/// Sequential, Parallel.For, JobWorkerPool, and WorkStealingPool.
+/// </summary>
+[MemoryDiagnoser]
+public class WaveSchedulerBenchmarks
+{
+    [Params(10, 100, 1000)]
+    public int EntityCount { get; set; }
+
+    private SharedWorld _sharedWorld = null!;
+    private World _world = null!;
+    private SystemSchedule<ComponentMask, DefaultConfig> _seqSchedule = null!;
+    private SystemSchedule<ComponentMask, DefaultConfig> _parSchedule = null!;
+    private SystemSchedule<ComponentMask, DefaultConfig> _jobSchedule = null!;
+    private SystemSchedule<ComponentMask, DefaultConfig> _wsSchedule = null!;
+    private JobWorkerPool _jobPool = null!;
+    private WorkStealingPool _wsPool = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _sharedWorld = SharedWorldFactory.Create();
+        _world = _sharedWorld.CreateWorld();
+
+        for (int i = 0; i < EntityCount; i++)
+        {
+            var e = _world.Spawn();
+            _world.AddComponent(e, new BenchPosition { X = i, Y = i * 2, Z = 0 });
+            _world.AddComponent(e, new BenchVelocity { X = 1, Y = 1, Z = 0 });
+        }
+
+        _seqSchedule = SystemSchedule.Create(_world)
+            .Add<BenchMovementSystem>()
+            .Build<SequentialWaveScheduler>();
+
+        _parSchedule = SystemSchedule.Create(_world)
+            .Add<BenchMovementSystem>()
+            .Build<ParallelWaveScheduler>();
+
+        _jobPool = new JobWorkerPool();
+        _jobSchedule = SystemSchedule.Create(_world)
+            .Add<BenchMovementSystem>()
+            .Build(new JobWaveScheduler(_jobPool));
+
+        _wsPool = new WorkStealingPool();
+        _wsSchedule = SystemSchedule.Create(_world)
+            .Add<BenchMovementSystem>()
+            .Build(new WorkStealingWaveScheduler(_wsPool));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _seqSchedule.Dispose();
+        _parSchedule.Dispose();
+        _jobSchedule.Dispose();
+        _wsSchedule.Dispose();
+        _jobPool.Dispose();
+        _wsPool.Dispose();
+        _sharedWorld.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public void Sequential() => _seqSchedule.Run();
+
+    [Benchmark]
+    public void ParallelFor() => _parSchedule.Run();
+
+    [Benchmark]
+    public void JobPool() => _jobSchedule.Run();
+
+    [Benchmark]
+    public void WorkStealing() => _wsSchedule.Run();
+}

--- a/src/Paradise.ECS.Jobs.Test/DelegateWorkItem.cs
+++ b/src/Paradise.ECS.Jobs.Test/DelegateWorkItem.cs
@@ -1,0 +1,23 @@
+namespace Paradise.ECS.Jobs.Test;
+
+/// <summary>
+/// Work item that wraps a delegate for testing.
+/// </summary>
+internal readonly struct DelegateWorkItem(Action action) : IWorkItem
+{
+    public void Invoke() => action();
+
+    /// <summary>
+    /// Creates a list of work items that call <paramref name="action"/> with indices 0 to <paramref name="count"/>-1.
+    /// </summary>
+    public static List<DelegateWorkItem> Create(int count, Action<int> action)
+    {
+        var items = new List<DelegateWorkItem>(count);
+        for (int i = 0; i < count; i++)
+        {
+            int index = i;
+            items.Add(new DelegateWorkItem(() => action(index)));
+        }
+        return items;
+    }
+}

--- a/src/Paradise.ECS.Jobs.Test/JobWaveSchedulerTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/JobWaveSchedulerTests.cs
@@ -1,0 +1,91 @@
+namespace Paradise.ECS.Jobs.Test;
+
+/// <summary>
+/// Tests for <see cref="JobWaveScheduler"/> — system scheduling with persistent worker pool.
+/// </summary>
+public sealed class JobWaveSchedulerTests : IDisposable
+{
+    private readonly SharedWorld _sharedWorld;
+    private readonly World _world;
+
+    public JobWaveSchedulerTests()
+    {
+        _sharedWorld = SharedWorldFactory.Create();
+        _world = _sharedWorld.CreateWorld();
+    }
+
+    public void Dispose()
+    {
+        _sharedWorld.Dispose();
+    }
+
+    [Test]
+    public async Task Schedule_RunJobScheduler_ProducesSameResultsAsSequential()
+    {
+        // Run sequential
+        var e1 = _world.Spawn();
+        _world.AddComponent(e1, new TestPosition { X = 10, Y = 20, Z = 0 });
+        _world.AddComponent(e1, new TestVelocity { X = 1, Y = 2, Z = 0 });
+
+        var seqSchedule = SystemSchedule.Create(_world)
+            .Add<TestMovementSystem>()
+            .Add<TestGravitySystem>()
+            .Build<SequentialWaveScheduler>();
+
+        seqSchedule.Run();
+        var seqPos = _world.GetComponent<TestPosition>(e1);
+        var seqVel = _world.GetComponent<TestVelocity>(e1);
+
+        // Reset and run with JobWaveScheduler
+        _world.Clear();
+        var e2 = _world.Spawn();
+        _world.AddComponent(e2, new TestPosition { X = 10, Y = 20, Z = 0 });
+        _world.AddComponent(e2, new TestVelocity { X = 1, Y = 2, Z = 0 });
+
+        using var pool = new JobWorkerPool(2);
+        var jobSchedule = SystemSchedule.Create(_world)
+            .Add<TestMovementSystem>()
+            .Add<TestGravitySystem>()
+            .Build(new JobWaveScheduler(pool));
+
+        jobSchedule.Run();
+        var jobPos = _world.GetComponent<TestPosition>(e2);
+        var jobVel = _world.GetComponent<TestVelocity>(e2);
+
+        await Assert.That(jobPos.X).IsEqualTo(seqPos.X);
+        await Assert.That(jobPos.Y).IsEqualTo(seqPos.Y);
+        await Assert.That(jobVel.Y).IsEqualTo(seqVel.Y);
+    }
+
+    [Test]
+    public async Task Schedule_RunJobScheduler_StressTestMultipleFrames()
+    {
+        using var pool = new JobWorkerPool(4);
+        const int entityCount = 200;
+        const int frameCount = 10;
+
+        // Create many entities
+        var entities = new Entity[entityCount];
+        for (int i = 0; i < entityCount; i++)
+        {
+            entities[i] = _world.Spawn();
+            _world.AddComponent(entities[i], new TestPosition { X = i, Y = i * 2, Z = 0 });
+            _world.AddComponent(entities[i], new TestVelocity { X = 1, Y = 1, Z = 0 });
+        }
+
+        var schedule = SystemSchedule.Create(_world)
+            .Add<TestMovementSystem>()
+            .Add<TestGravitySystem>()
+            .Build(new JobWaveScheduler(pool));
+
+        for (int frame = 0; frame < frameCount; frame++)
+            schedule.Run();
+
+        // Verify all entities were processed — positions should have increased
+        for (int i = 0; i < entityCount; i++)
+        {
+            var pos = _world.GetComponent<TestPosition>(entities[i]);
+            await Assert.That(pos.X).IsGreaterThan((float)i);
+        }
+    }
+}

--- a/src/Paradise.ECS.Jobs.Test/JobWorkerPoolTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/JobWorkerPoolTests.cs
@@ -1,0 +1,327 @@
+namespace Paradise.ECS.Jobs.Test;
+
+/// <summary>
+/// Tests for <see cref="JobWorkerPool"/> — persistent worker thread pool.
+/// </summary>
+public sealed class JobWorkerPoolTests
+{
+    // ---- Basic Functionality ----
+
+    [Test]
+    public async Task ExecuteWork_ZeroItems_IsNoOp()
+    {
+        using var pool = new JobWorkerPool(2);
+        var invoked = false;
+        pool.ExecuteWork(DelegateWorkItem.Create(0, _ => invoked = true));
+        await Assert.That(invoked).IsFalse();
+    }
+
+    [Test]
+    public async Task ExecuteWork_SingleItem_ExecutesOnCallingThread()
+    {
+        using var pool = new JobWorkerPool(2);
+        var callingThreadId = Environment.CurrentManagedThreadId;
+        var executedThreadId = -1;
+
+        pool.ExecuteWork(DelegateWorkItem.Create(1, _ => executedThreadId = Environment.CurrentManagedThreadId));
+
+        await Assert.That(executedThreadId).IsEqualTo(callingThreadId);
+    }
+
+    [Test]
+    public async Task ExecuteWork_MultipleItems_AllProcessedExactlyOnce()
+    {
+        using var pool = new JobWorkerPool(4);
+        const int count = 1000;
+        var results = new int[count];
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Increment(ref results[i])));
+
+        for (int i = 0; i < count; i++)
+            await Assert.That(results[i]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteWork_MultipleConsecutiveWaves_WorksRepeatedly()
+    {
+        using var pool = new JobWorkerPool(3);
+
+        for (int wave = 0; wave < 10; wave++)
+        {
+            const int count = 100;
+            var sum = 0;
+            pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Add(ref sum, i)));
+
+            int expected = count * (count - 1) / 2;
+            await Assert.That(sum).IsEqualTo(expected);
+        }
+    }
+
+    [Test]
+    public async Task ExecuteWork_MoreWorkersThanItems_NoErrors()
+    {
+        using var pool = new JobWorkerPool(8);
+        const int count = 3;
+        var results = new int[count];
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Increment(ref results[i])));
+
+        for (int i = 0; i < count; i++)
+            await Assert.That(results[i]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteWork_StressTest_LargeItemCount()
+    {
+        using var pool = new JobWorkerPool();
+        const int count = 100_000;
+        var sum = 0L;
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Add(ref sum, i)));
+
+        long expected = (long)count * (count - 1) / 2;
+        await Assert.That(sum).IsEqualTo(expected);
+    }
+
+    // ---- Worker Count ----
+
+    [Test]
+    public async Task WorkerCount_DefaultValue_IsAtLeastOne()
+    {
+        using var pool = new JobWorkerPool();
+        await Assert.That(pool.WorkerCount).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task WorkerCount_ExplicitValue_ReturnsConfiguredCount()
+    {
+        using var pool = new JobWorkerPool(5);
+        await Assert.That(pool.WorkerCount).IsEqualTo(5);
+    }
+
+    // ---- Dispose ----
+
+    [Test]
+    public async Task ExecuteWork_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var pool = new JobWorkerPool(2);
+        pool.Dispose();
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(1, _ => { }));
+        }
+        catch (ObjectDisposedException)
+        {
+            threw = true;
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    [Test]
+    public async Task Dispose_CalledTwice_DoesNotThrow()
+    {
+        var pool = new JobWorkerPool(2);
+        pool.Dispose();
+        pool.Dispose(); // should not throw
+        await Assert.That(pool.WorkerCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Dispose_DuringExecution_WaitsForCompletion()
+    {
+        using var started = new ManualResetEventSlim(false);
+        var pool = new JobWorkerPool(2);
+        var completed = 0;
+
+        // Start work on a background thread
+        var workTask = Task.Run(() =>
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(100, i =>
+            {
+                if (i == 0) started.Set();
+                Thread.SpinWait(1000);
+                Interlocked.Increment(ref completed);
+            }));
+        });
+
+        // Wait for work to begin, then try to dispose
+        started.Wait();
+        pool.Dispose();
+
+        // Work should have completed before Dispose returned
+        await Assert.That(completed).IsEqualTo(100);
+    }
+
+    // ---- Exception Safety ----
+
+    [Test]
+    public async Task ExecuteWork_SingleException_ThrowsAggregateException()
+    {
+        using var pool = new JobWorkerPool(2);
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(10, i =>
+            {
+                if (i == 5)
+                    throw new InvalidOperationException("boom");
+            }));
+        }
+        catch (AggregateException ex)
+        {
+            threw = true;
+            await Assert.That(ex.InnerExceptions.Count).IsEqualTo(1);
+            await Assert.That(ex.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    [Test]
+    public async Task ExecuteWork_MultipleExceptions_CapturesAll()
+    {
+        using var pool = new JobWorkerPool(2);
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(10, i =>
+            {
+                if (i % 3 == 0)
+                    throw new InvalidOperationException($"error-{i}");
+            }));
+        }
+        catch (AggregateException ex)
+        {
+            threw = true;
+            // Items 0, 3, 6, 9 throw → 4 exceptions
+            await Assert.That(ex.InnerExceptions.Count).IsEqualTo(4);
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    [Test]
+    public async Task ExecuteWork_AfterException_PoolReusable()
+    {
+        using var pool = new JobWorkerPool(2);
+
+        // First call throws
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(10, i =>
+            {
+                if (i == 0) throw new InvalidOperationException("first");
+            }));
+        }
+        catch (AggregateException)
+        {
+            // expected
+        }
+
+        // Pool should still be usable
+        var sum = 0;
+        pool.ExecuteWork(DelegateWorkItem.Create(100, i => Interlocked.Add(ref sum, i)));
+        int expected = 100 * 99 / 2;
+        await Assert.That(sum).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ExecuteWork_AllItemsComplete_DespiteExceptions()
+    {
+        using var pool = new JobWorkerPool(4);
+        var processedCount = 0;
+
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(20, i =>
+            {
+                Interlocked.Increment(ref processedCount);
+                if (i == 10)
+                    throw new InvalidOperationException("mid-stream");
+            }));
+        }
+        catch (AggregateException)
+        {
+            // expected
+        }
+
+        // All 20 items should have been processed even though one threw
+        await Assert.That(processedCount).IsEqualTo(20);
+    }
+
+    // ---- Reentrancy Guard ----
+
+    [Test]
+    public async Task ExecuteWork_ReentrantCall_ThrowsInvalidOperationException()
+    {
+        using var pool = new JobWorkerPool(2);
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(10, _ =>
+            {
+                // Attempt reentrant call from worker
+                pool.ExecuteWork(DelegateWorkItem.Create(5, _ => { }));
+            }));
+        }
+        catch (AggregateException ex)
+        {
+            // The reentrant call throws InvalidOperationException, which is captured
+            threw = ex.InnerExceptions.Any(e => e is InvalidOperationException);
+        }
+        catch (InvalidOperationException)
+        {
+            // Could also be thrown directly if main thread hits it
+            threw = true;
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    // ---- Batch Claiming ----
+
+    [Test]
+    public async Task ExecuteWork_BatchClaiming_AllItemsProcessedExactlyOnce()
+    {
+        using var pool = new JobWorkerPool(4);
+        const int count = 1000;
+        var results = new int[count];
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Increment(ref results[i])));
+
+        for (int i = 0; i < count; i++)
+            await Assert.That(results[i]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteWork_CountLessThanBatchSize_AllItemsProcessed()
+    {
+        using var pool = new JobWorkerPool(4);
+        const int count = 3; // Less than batch size of 8
+        var results = new int[count];
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Increment(ref results[i])));
+
+        for (int i = 0; i < count; i++)
+            await Assert.That(results[i]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteWork_CountNotMultipleOfBatchSize_AllItemsProcessed()
+    {
+        using var pool = new JobWorkerPool(4);
+        const int count = 37; // Not a multiple of batch size 8
+        var results = new int[count];
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Increment(ref results[i])));
+
+        for (int i = 0; i < count; i++)
+            await Assert.That(results[i]).IsEqualTo(1);
+    }
+}

--- a/src/Paradise.ECS.Jobs.Test/JobWorkerPoolTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/JobWorkerPoolTests.cs
@@ -182,6 +182,32 @@ public sealed class JobWorkerPoolTests
     }
 
     [Test]
+    public async Task ExecuteWork_SingleItemException_ThrowsAggregateException()
+    {
+        // Single-item waves take a fast-path that bypasses the worker pool.
+        // The exception shape must still match the multi-item path (AggregateException
+        // wrapping the inner exception) so callers writing `catch (AggregateException)`
+        // do not silently miss exceptions thrown from one-item waves.
+        using var pool = new JobWorkerPool(2);
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(1, _ =>
+                throw new InvalidOperationException("solo")));
+        }
+        catch (AggregateException ex)
+        {
+            threw = true;
+            await Assert.That(ex.InnerExceptions.Count).IsEqualTo(1);
+            await Assert.That(ex.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
+            await Assert.That(ex.InnerExceptions[0].Message).IsEqualTo("solo");
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    [Test]
     public async Task ExecuteWork_MultipleExceptions_CapturesAll()
     {
         using var pool = new JobWorkerPool(2);

--- a/src/Paradise.ECS.Jobs.Test/Paradise.ECS.Jobs.Test.csproj
+++ b/src/Paradise.ECS.Jobs.Test/Paradise.ECS.Jobs.Test.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Paradise.ECS.Common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <!-- Allow underscore naming convention in test methods -->
+    <!-- CA1515: Test classes need to be public for TUnit discovery -->
+    <!-- PECS016: Allow testing empty components (zero-size marker types) -->
+    <NoWarn>$(NoWarn);CA1707;CA1515;PECS016</NoWarn>
+    <!-- Native AOT support -->
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paradise.ECS.Jobs\Paradise.ECS.Jobs.csproj" />
+    <ProjectReference Include="..\Paradise.ECS\Paradise.ECS.csproj" />
+    <ProjectReference Include="..\Paradise.ECS.Generators\Paradise.ECS.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Paradise.ECS" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paradise.ECS.Jobs.Test/TestComponents.cs
+++ b/src/Paradise.ECS.Jobs.Test/TestComponents.cs
@@ -1,0 +1,32 @@
+namespace Paradise.ECS.Jobs.Test;
+
+/// <summary>
+/// Test components for unit testing with explicit manual IDs.
+/// </summary>
+[Component("5B9313BE-CB77-4C8B-A0E4-82A3B369C717", Id = 0)]
+public partial struct TestHealth
+{
+    public int Current;
+    public int Max;
+}
+
+[Component("B6170E3B-FEE1-4C16-85C9-B5130A253BAC", Id = 1)]
+public partial struct TestPosition
+{
+    public float X, Y, Z;
+}
+
+[Component("1040E96A-7D4A-4241-BDE1-36D4DBFCF7C0", Id = 2)]
+public partial struct TestVelocity
+{
+    public float X, Y, Z;
+}
+
+[Component("A7B3C4D5-E6F7-4890-ABCD-1234567890AB", Id = 3)]
+public partial struct TestTag;
+
+[Component("B8C4D5E6-F7A8-4901-BCDE-2345678901BC", Id = 4)]
+public partial struct TestDamage
+{
+    public int Amount;
+}

--- a/src/Paradise.ECS.Jobs.Test/TestSystems.cs
+++ b/src/Paradise.ECS.Jobs.Test/TestSystems.cs
@@ -1,0 +1,28 @@
+namespace Paradise.ECS.Jobs.Test;
+
+/// <summary>
+/// Test system: adds velocity to position per entity.
+/// </summary>
+public ref partial struct TestMovementSystem : IEntitySystem
+{
+    public ref TestPosition Position;
+    public ref readonly TestVelocity Velocity;
+
+    public void Execute()
+    {
+        Position = new TestPosition { X = Position.X + Velocity.X, Y = Position.Y + Velocity.Y, Z = Position.Z + Velocity.Z };
+    }
+}
+
+/// <summary>
+/// Test system: multiplies velocity Y by 2.
+/// </summary>
+public ref partial struct TestGravitySystem : IEntitySystem
+{
+    public ref TestVelocity Velocity;
+
+    public void Execute()
+    {
+        Velocity = new TestVelocity { X = Velocity.X, Y = Velocity.Y * 2, Z = Velocity.Z };
+    }
+}

--- a/src/Paradise.ECS.Jobs.Test/WorkStealingDequeTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/WorkStealingDequeTests.cs
@@ -234,7 +234,11 @@ public sealed class WorkStealingDequeTests
         foreach (var t in stealers)
             t.Join();
 
-        // Verify every item retrieved exactly once
+        // Verify every item retrieved exactly once.
+        // Total count assertion comes BEFORE deduplication so a duplicate
+        // (same item delivered to two consumers) fails the test — without it,
+        // HashSet alone would still pass on duplicates.
+        await Assert.That(collected.Count).IsEqualTo(itemCount);
         var seen = new HashSet<int>(collected);
         await Assert.That(seen.Count).IsEqualTo(itemCount);
         for (int i = 0; i < itemCount; i++)

--- a/src/Paradise.ECS.Jobs.Test/WorkStealingDequeTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/WorkStealingDequeTests.cs
@@ -240,4 +240,87 @@ public sealed class WorkStealingDequeTests
         for (int i = 0; i < itemCount; i++)
             await Assert.That(seen.Contains(i)).IsTrue();
     }
+
+    /// <summary>
+    /// Stress test that forces many <c>Grow()</c> operations to run concurrently with
+    /// <c>Steal()</c> calls. Starts with a deliberately tiny initial capacity (2) and
+    /// pushes a large number of items so the deque grows repeatedly while several
+    /// stealer threads are actively racing the owner. With the canonical Chase-Lev
+    /// pre-CAS buffer read used by <see cref="WorkStealingDeque.Steal"/>, every pushed
+    /// item must be consumed exactly once — no duplicates and no losses, even though
+    /// the buffer reference can be swapped underneath the stealer arbitrarily often.
+    ///
+    /// This regression-tests the slot-stability guarantee documented in
+    /// <see cref="WorkStealingDeque.Steal"/>: the old buffer is never mutated after a
+    /// swap, and slot t is preserved across any Grow that happens before the stealer's
+    /// CAS. Repeats the workload many times to widen the race window across CI runs.
+    /// </summary>
+    [Test]
+    public async Task ConcurrentStealAcrossManyGrows_AllItemsAccountedForExactlyOnce()
+    {
+        const int iterations = 20;
+        const int itemCount = 20_000;
+        const int stealerCount = 4;
+        const int initialCapacity = 2; // Tiny so Grow() runs ~log2(itemCount) times per iteration.
+
+        for (int iter = 0; iter < iterations; iter++)
+        {
+            var deque = new WorkStealingDeque(initialCapacity);
+            var collected = new ConcurrentBag<int>();
+            using var startBarrier = new Barrier(stealerCount + 1);
+            var stealersDone = new bool[1];
+
+            var stealers = new Thread[stealerCount];
+            for (int s = 0; s < stealerCount; s++)
+            {
+                stealers[s] = new Thread(() =>
+                {
+                    startBarrier.SignalAndWait();
+                    while (!Volatile.Read(ref stealersDone[0]))
+                    {
+                        int item = deque.Steal();
+                        if (item >= 0)
+                            collected.Add(item);
+                    }
+                    int drained;
+                    while ((drained = deque.Steal()) >= 0)
+                        collected.Add(drained);
+                });
+                stealers[s].Start();
+            }
+
+            // Owner: push everything as fast as possible so Grow() is forced to run
+            // many times while stealers are actively contending for top.
+            startBarrier.SignalAndWait();
+            for (int i = 0; i < itemCount; i++)
+                deque.PushBottom(i);
+
+            // Drain owner's remaining items via PopBottom (LIFO). Stealers continue
+            // to race until we set the done flag.
+            int popped;
+            while ((popped = deque.PopBottom()) >= 0)
+                collected.Add(popped);
+
+            Volatile.Write(ref stealersDone[0], true);
+            foreach (var t in stealers)
+                t.Join();
+
+            // Final drain in case any item was pushed in the gap (defensive).
+            int last;
+            while ((last = deque.PopBottom()) >= 0)
+                collected.Add(last);
+            while ((last = deque.Steal()) >= 0)
+                collected.Add(last);
+
+            // Every pushed item must appear exactly once. Duplicates would indicate
+            // a stealer returned a stale value and the owner also popped the same
+            // logical slot; missing items would indicate a stealer overwrote a slot
+            // the owner needed (or returned garbage outside [0, itemCount)).
+            await Assert.That(collected.Count).IsEqualTo(itemCount).Because($"iter={iter}: total collected count");
+            var seen = new HashSet<int>(collected);
+            await Assert.That(seen.Count).IsEqualTo(itemCount).Because($"iter={iter}: distinct count");
+            await Assert.That(seen.Min()).IsEqualTo(0).Because($"iter={iter}: smallest collected");
+            await Assert.That(seen.Max()).IsEqualTo(itemCount - 1).Because($"iter={iter}: largest collected");
+        }
+    }
 }

--- a/src/Paradise.ECS.Jobs.Test/WorkStealingDequeTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/WorkStealingDequeTests.cs
@@ -1,0 +1,243 @@
+using System.Collections.Concurrent;
+
+namespace Paradise.ECS.Jobs.Test;
+
+/// <summary>
+/// Unit tests for <see cref="WorkStealingDeque"/> — the Chase-Lev work-stealing deque.
+/// Covers LIFO/FIFO ordering, empty states, growth, reset, and concurrent correctness.
+/// </summary>
+public sealed class WorkStealingDequeTests
+{
+    // ---- Basic Ordering ----
+
+    [Test]
+    public async Task PopBottom_MultipleItems_ReturnsInLifoOrder()
+    {
+        var deque = new WorkStealingDeque(8);
+        for (int i = 0; i < 5; i++)
+            deque.PushBottom(i);
+
+        for (int i = 4; i >= 0; i--)
+            await Assert.That(deque.PopBottom()).IsEqualTo(i);
+    }
+
+    [Test]
+    public async Task Steal_MultipleItems_ReturnsInFifoOrder()
+    {
+        var deque = new WorkStealingDeque(8);
+        for (int i = 0; i < 5; i++)
+            deque.PushBottom(i);
+
+        for (int i = 0; i < 5; i++)
+            await Assert.That(deque.Steal()).IsEqualTo(i);
+    }
+
+    // ---- Empty Deque ----
+
+    [Test]
+    public async Task PopBottom_EmptyDeque_ReturnsNegativeOne()
+    {
+        var deque = new WorkStealingDeque(4);
+        await Assert.That(deque.PopBottom()).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task Steal_EmptyDeque_ReturnsNegativeOne()
+    {
+        var deque = new WorkStealingDeque(4);
+        await Assert.That(deque.Steal()).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task PopBottom_AfterDrain_ReturnsNegativeOne()
+    {
+        var deque = new WorkStealingDeque(4);
+        deque.PushBottom(42);
+        deque.PopBottom();
+        await Assert.That(deque.PopBottom()).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task Steal_AfterDrain_ReturnsNegativeOne()
+    {
+        var deque = new WorkStealingDeque(4);
+        deque.PushBottom(42);
+        deque.Steal();
+        await Assert.That(deque.Steal()).IsEqualTo(-1);
+    }
+
+    // ---- Count ----
+
+    [Test]
+    public async Task Count_AfterPushAndPop_ReflectsCurrentSize()
+    {
+        var deque = new WorkStealingDeque(8);
+        await Assert.That(deque.Count).IsEqualTo(0);
+
+        deque.PushBottom(1);
+        deque.PushBottom(2);
+        deque.PushBottom(3);
+        await Assert.That(deque.Count).IsEqualTo(3);
+
+        deque.PopBottom();
+        await Assert.That(deque.Count).IsEqualTo(2);
+
+        deque.Steal();
+        await Assert.That(deque.Count).IsEqualTo(1);
+    }
+
+    // ---- Growth ----
+
+    [Test]
+    public async Task PushBottom_ExceedsInitialCapacity_GrowsAndRetainsAllItems()
+    {
+        var deque = new WorkStealingDeque(4); // initial capacity 4
+        const int count = 100;
+
+        for (int i = 0; i < count; i++)
+            deque.PushBottom(i);
+
+        int retrieved = deque.Count;
+        await Assert.That(retrieved).IsEqualTo(count);
+
+        // Pop all in LIFO order to verify data integrity after growth
+        for (int i = count - 1; i >= 0; i--)
+            await Assert.That(deque.PopBottom()).IsEqualTo(i);
+    }
+
+    // ---- Reset ----
+
+    [Test]
+    public async Task Reset_ClearsDeque_ThenPushPopWorks()
+    {
+        var deque = new WorkStealingDeque(8);
+        deque.PushBottom(10);
+        deque.PushBottom(20);
+
+        deque.Reset();
+        await Assert.That(deque.Count).IsEqualTo(0);
+        await Assert.That(deque.PopBottom()).IsEqualTo(-1);
+        await Assert.That(deque.Steal()).IsEqualTo(-1);
+
+        // Push/pop works after reset
+        deque.PushBottom(30);
+        await Assert.That(deque.PopBottom()).IsEqualTo(30);
+    }
+
+    [Test]
+    public async Task Reset_WithLargerCapacity_ExpandsBuffer()
+    {
+        var deque = new WorkStealingDeque(4);
+        deque.Reset(capacity: 128);
+
+        // Should accommodate 128 items without growing
+        for (int i = 0; i < 128; i++)
+            deque.PushBottom(i);
+
+        await Assert.That(deque.Count).IsEqualTo(128);
+    }
+
+    // ---- Single-Element Race ----
+
+    [Test]
+    public async Task SingleElement_ConcurrentPopAndSteal_ExactlyOneSucceeds()
+    {
+        const int iterations = 10_000;
+        int bothSucceeded = 0;
+        int neitherSucceeded = 0;
+
+        for (int iter = 0; iter < iterations; iter++)
+        {
+            var deque = new WorkStealingDeque(4);
+            deque.PushBottom(42);
+
+            int popResult = -1;
+            int stealResult = -1;
+
+            using var barrier = new Barrier(2);
+
+            var stealerThread = new Thread(() =>
+            {
+                barrier.SignalAndWait();
+                stealResult = deque.Steal();
+            });
+
+            stealerThread.Start();
+            barrier.SignalAndWait();
+            popResult = deque.PopBottom();
+            stealerThread.Join();
+
+            int successes = (popResult >= 0 ? 1 : 0) + (stealResult >= 0 ? 1 : 0);
+            if (successes == 2) bothSucceeded++;
+            if (successes == 0) neitherSucceeded++;
+        }
+
+        // Exactly one must succeed per iteration — never both, never neither
+        await Assert.That(bothSucceeded).IsEqualTo(0);
+        await Assert.That(neitherSucceeded).IsEqualTo(0);
+    }
+
+    // ---- Concurrent Stress ----
+
+    [Test]
+    public async Task ConcurrentPushPopAndSteal_AllItemsAccountedFor()
+    {
+        const int itemCount = 50_000;
+        const int stealerCount = 4;
+        var deque = new WorkStealingDeque(64);
+        var collected = new ConcurrentBag<int>();
+
+        using var startBarrier = new Barrier(stealerCount + 1);
+
+        // Stealer threads
+        var stealers = new Thread[stealerCount];
+        var stealerDone = new bool[1]; // signal stealers to stop via Volatile.Read/Write
+        for (int s = 0; s < stealerCount; s++)
+        {
+            stealers[s] = new Thread(() =>
+            {
+                startBarrier.SignalAndWait();
+                while (!Volatile.Read(ref stealerDone[0]))
+                {
+                    int item = deque.Steal();
+                    if (item >= 0)
+                        collected.Add(item);
+                }
+                // Drain remaining
+                int remaining;
+                while ((remaining = deque.Steal()) >= 0)
+                    collected.Add(remaining);
+            });
+            stealers[s].Start();
+        }
+
+        // Owner thread: push all, then pop remaining
+        startBarrier.SignalAndWait();
+        for (int i = 0; i < itemCount; i++)
+        {
+            deque.PushBottom(i);
+            // Occasionally pop from our own end to simulate real owner behavior
+            if (i % 7 == 0)
+            {
+                int popped = deque.PopBottom();
+                if (popped >= 0)
+                    collected.Add(popped);
+            }
+        }
+
+        // Drain owner's remaining items
+        int item2;
+        while ((item2 = deque.PopBottom()) >= 0)
+            collected.Add(item2);
+
+        Volatile.Write(ref stealerDone[0], true);
+        foreach (var t in stealers)
+            t.Join();
+
+        // Verify every item retrieved exactly once
+        var seen = new HashSet<int>(collected);
+        await Assert.That(seen.Count).IsEqualTo(itemCount);
+        for (int i = 0; i < itemCount; i++)
+            await Assert.That(seen.Contains(i)).IsTrue();
+    }
+}

--- a/src/Paradise.ECS.Jobs.Test/WorkStealingPoolTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/WorkStealingPoolTests.cs
@@ -180,6 +180,32 @@ public sealed class WorkStealingPoolTests
     }
 
     [Test]
+    public async Task ExecuteWork_SingleItemException_ThrowsAggregateException()
+    {
+        // Single-item waves take a fast-path that bypasses the worker pool.
+        // The exception shape must still match the multi-item path (AggregateException
+        // wrapping the inner exception) so callers writing `catch (AggregateException)`
+        // do not silently miss exceptions thrown from one-item waves.
+        using var pool = new WorkStealingPool(2);
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(1, _ =>
+                throw new InvalidOperationException("solo")));
+        }
+        catch (AggregateException ex)
+        {
+            threw = true;
+            await Assert.That(ex.InnerExceptions.Count).IsEqualTo(1);
+            await Assert.That(ex.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
+            await Assert.That(ex.InnerExceptions[0].Message).IsEqualTo("solo");
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    [Test]
     public async Task ExecuteWork_MultipleExceptions_CapturesAll()
     {
         using var pool = new WorkStealingPool(2);

--- a/src/Paradise.ECS.Jobs.Test/WorkStealingPoolTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/WorkStealingPoolTests.cs
@@ -1,0 +1,299 @@
+namespace Paradise.ECS.Jobs.Test;
+
+/// <summary>
+/// Tests for <see cref="WorkStealingPool"/> — work-stealing thread pool.
+/// Mirrors <see cref="JobWorkerPoolTests"/> for API parity.
+/// </summary>
+public sealed class WorkStealingPoolTests
+{
+    // ---- Basic Functionality ----
+
+    [Test]
+    public async Task ExecuteWork_ZeroItems_IsNoOp()
+    {
+        using var pool = new WorkStealingPool(2);
+        var invoked = false;
+        pool.ExecuteWork(DelegateWorkItem.Create(0, _ => invoked = true));
+        await Assert.That(invoked).IsFalse();
+    }
+
+    [Test]
+    public async Task ExecuteWork_SingleItem_ExecutesOnCallingThread()
+    {
+        using var pool = new WorkStealingPool(2);
+        var callingThreadId = Environment.CurrentManagedThreadId;
+        var executedThreadId = -1;
+
+        pool.ExecuteWork(DelegateWorkItem.Create(1, _ => executedThreadId = Environment.CurrentManagedThreadId));
+
+        await Assert.That(executedThreadId).IsEqualTo(callingThreadId);
+    }
+
+    [Test]
+    public async Task ExecuteWork_MultipleItems_AllProcessedExactlyOnce()
+    {
+        using var pool = new WorkStealingPool(4);
+        const int count = 1000;
+        var results = new int[count];
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Increment(ref results[i])));
+
+        for (int i = 0; i < count; i++)
+            await Assert.That(results[i]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteWork_MultipleConsecutiveWaves_WorksRepeatedly()
+    {
+        using var pool = new WorkStealingPool(3);
+
+        for (int wave = 0; wave < 10; wave++)
+        {
+            const int count = 100;
+            var sum = 0;
+            pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Add(ref sum, i)));
+
+            int expected = count * (count - 1) / 2;
+            await Assert.That(sum).IsEqualTo(expected);
+        }
+    }
+
+    [Test]
+    public async Task ExecuteWork_MoreWorkersThanItems_NoErrors()
+    {
+        using var pool = new WorkStealingPool(8);
+        const int count = 3;
+        var results = new int[count];
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Increment(ref results[i])));
+
+        for (int i = 0; i < count; i++)
+            await Assert.That(results[i]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteWork_StressTest_LargeItemCount()
+    {
+        using var pool = new WorkStealingPool();
+        const int count = 100_000;
+        var sum = 0L;
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i => Interlocked.Add(ref sum, i)));
+
+        long expected = (long)count * (count - 1) / 2;
+        await Assert.That(sum).IsEqualTo(expected);
+    }
+
+    // ---- Worker Count ----
+
+    [Test]
+    public async Task WorkerCount_DefaultValue_IsAtLeastOne()
+    {
+        using var pool = new WorkStealingPool();
+        await Assert.That(pool.WorkerCount).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task WorkerCount_ExplicitValue_ReturnsConfiguredCount()
+    {
+        using var pool = new WorkStealingPool(5);
+        await Assert.That(pool.WorkerCount).IsEqualTo(5);
+    }
+
+    // ---- Dispose ----
+
+    [Test]
+    public async Task ExecuteWork_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var pool = new WorkStealingPool(2);
+        pool.Dispose();
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(1, _ => { }));
+        }
+        catch (ObjectDisposedException)
+        {
+            threw = true;
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    [Test]
+    public async Task Dispose_CalledTwice_DoesNotThrow()
+    {
+        var pool = new WorkStealingPool(2);
+        pool.Dispose();
+        pool.Dispose(); // should not throw
+        await Assert.That(pool.WorkerCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Dispose_DuringExecution_WaitsForCompletion()
+    {
+        using var started = new ManualResetEventSlim(false);
+        var pool = new WorkStealingPool(2);
+        var completed = 0;
+
+        var workTask = Task.Run(() =>
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(100, i =>
+            {
+                if (i == 0) started.Set();
+                Thread.SpinWait(1000);
+                Interlocked.Increment(ref completed);
+            }));
+        });
+
+        started.Wait();
+        pool.Dispose();
+
+        await Assert.That(completed).IsEqualTo(100);
+    }
+
+    // ---- Exception Safety ----
+
+    [Test]
+    public async Task ExecuteWork_SingleException_ThrowsAggregateException()
+    {
+        using var pool = new WorkStealingPool(2);
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(10, i =>
+            {
+                if (i == 5)
+                    throw new InvalidOperationException("boom");
+            }));
+        }
+        catch (AggregateException ex)
+        {
+            threw = true;
+            await Assert.That(ex.InnerExceptions.Count).IsEqualTo(1);
+            await Assert.That(ex.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    [Test]
+    public async Task ExecuteWork_MultipleExceptions_CapturesAll()
+    {
+        using var pool = new WorkStealingPool(2);
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(10, i =>
+            {
+                if (i % 3 == 0)
+                    throw new InvalidOperationException($"error-{i}");
+            }));
+        }
+        catch (AggregateException ex)
+        {
+            threw = true;
+            await Assert.That(ex.InnerExceptions.Count).IsEqualTo(4);
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    [Test]
+    public async Task ExecuteWork_AfterException_PoolReusable()
+    {
+        using var pool = new WorkStealingPool(2);
+
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(10, i =>
+            {
+                if (i == 0) throw new InvalidOperationException("first");
+            }));
+        }
+        catch (AggregateException)
+        {
+            // expected
+        }
+
+        var sum = 0;
+        pool.ExecuteWork(DelegateWorkItem.Create(100, i => Interlocked.Add(ref sum, i)));
+        int expected = 100 * 99 / 2;
+        await Assert.That(sum).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ExecuteWork_AllItemsComplete_DespiteExceptions()
+    {
+        using var pool = new WorkStealingPool(4);
+        var processedCount = 0;
+
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(20, i =>
+            {
+                Interlocked.Increment(ref processedCount);
+                if (i == 10)
+                    throw new InvalidOperationException("mid-stream");
+            }));
+        }
+        catch (AggregateException)
+        {
+            // expected
+        }
+
+        await Assert.That(processedCount).IsEqualTo(20);
+    }
+
+    // ---- Reentrancy Guard ----
+
+    [Test]
+    public async Task ExecuteWork_ReentrantCall_ThrowsInvalidOperationException()
+    {
+        using var pool = new WorkStealingPool(2);
+
+        var threw = false;
+        try
+        {
+            pool.ExecuteWork(DelegateWorkItem.Create(10, _ =>
+            {
+                pool.ExecuteWork(DelegateWorkItem.Create(5, _ => { }));
+            }));
+        }
+        catch (AggregateException ex)
+        {
+            threw = ex.InnerExceptions.Any(e => e is InvalidOperationException);
+        }
+        catch (InvalidOperationException)
+        {
+            threw = true;
+        }
+
+        await Assert.That(threw).IsTrue();
+    }
+
+    // ---- Work Stealing Behavior ----
+
+    [Test]
+    public async Task ExecuteWork_UnevenWorkload_CompletesAllItems()
+    {
+        // Simulate uneven work — some items take much longer
+        using var pool = new WorkStealingPool(4);
+        const int count = 200;
+        var results = new int[count];
+
+        pool.ExecuteWork(DelegateWorkItem.Create(count, i =>
+        {
+            // Items 0-9 are "heavy" — work stealing should help
+            if (i < 10)
+                Thread.SpinWait(10000);
+            Interlocked.Increment(ref results[i]);
+        }));
+
+        for (int i = 0; i < count; i++)
+            await Assert.That(results[i]).IsEqualTo(1);
+    }
+}

--- a/src/Paradise.ECS.Jobs.Test/WorkStealingWaveSchedulerTests.cs
+++ b/src/Paradise.ECS.Jobs.Test/WorkStealingWaveSchedulerTests.cs
@@ -1,0 +1,140 @@
+namespace Paradise.ECS.Jobs.Test;
+
+/// <summary>
+/// Tests for <see cref="WorkStealingWaveScheduler"/> — system scheduling with work-stealing pool.
+/// </summary>
+public sealed class WorkStealingWaveSchedulerTests : IDisposable
+{
+    private readonly SharedWorld _sharedWorld;
+    private readonly World _world;
+
+    public WorkStealingWaveSchedulerTests()
+    {
+        _sharedWorld = SharedWorldFactory.Create();
+        _world = _sharedWorld.CreateWorld();
+    }
+
+    public void Dispose()
+    {
+        _sharedWorld.Dispose();
+    }
+
+    [Test]
+    public async Task Schedule_RunWorkStealingScheduler_ProducesSameResultsAsSequential()
+    {
+        // Run sequential
+        var e1 = _world.Spawn();
+        _world.AddComponent(e1, new TestPosition { X = 10, Y = 20, Z = 0 });
+        _world.AddComponent(e1, new TestVelocity { X = 1, Y = 2, Z = 0 });
+
+        var seqSchedule = SystemSchedule.Create(_world)
+            .Add<TestMovementSystem>()
+            .Add<TestGravitySystem>()
+            .Build<SequentialWaveScheduler>();
+
+        seqSchedule.Run();
+        var seqPos = _world.GetComponent<TestPosition>(e1);
+        var seqVel = _world.GetComponent<TestVelocity>(e1);
+
+        // Reset and run with WorkStealingWaveScheduler
+        _world.Clear();
+        var e2 = _world.Spawn();
+        _world.AddComponent(e2, new TestPosition { X = 10, Y = 20, Z = 0 });
+        _world.AddComponent(e2, new TestVelocity { X = 1, Y = 2, Z = 0 });
+
+        using var pool = new WorkStealingPool(2);
+        var wsSchedule = SystemSchedule.Create(_world)
+            .Add<TestMovementSystem>()
+            .Add<TestGravitySystem>()
+            .Build(new WorkStealingWaveScheduler(pool));
+
+        wsSchedule.Run();
+        var wsPos = _world.GetComponent<TestPosition>(e2);
+        var wsVel = _world.GetComponent<TestVelocity>(e2);
+
+        await Assert.That(wsPos.X).IsEqualTo(seqPos.X);
+        await Assert.That(wsPos.Y).IsEqualTo(seqPos.Y);
+        await Assert.That(wsVel.Y).IsEqualTo(seqVel.Y);
+    }
+
+    [Test]
+    public async Task Schedule_RunWorkStealingScheduler_StressTestMultipleFrames()
+    {
+        using var pool = new WorkStealingPool(4);
+        const int entityCount = 200;
+        const int frameCount = 10;
+
+        var entities = new Entity[entityCount];
+        for (int i = 0; i < entityCount; i++)
+        {
+            entities[i] = _world.Spawn();
+            _world.AddComponent(entities[i], new TestPosition { X = i, Y = i * 2, Z = 0 });
+            _world.AddComponent(entities[i], new TestVelocity { X = 1, Y = 1, Z = 0 });
+        }
+
+        var schedule = SystemSchedule.Create(_world)
+            .Add<TestMovementSystem>()
+            .Add<TestGravitySystem>()
+            .Build(new WorkStealingWaveScheduler(pool));
+
+        for (int frame = 0; frame < frameCount; frame++)
+            schedule.Run();
+
+        for (int i = 0; i < entityCount; i++)
+        {
+            var pos = _world.GetComponent<TestPosition>(entities[i]);
+            await Assert.That(pos.X).IsGreaterThan((float)i);
+        }
+    }
+
+    [Test]
+    public async Task Schedule_WorkStealingMatchesJobScheduler_SameResults()
+    {
+        const int entityCount = 50;
+
+        // Run with JobWaveScheduler
+        var entities1 = new Entity[entityCount];
+        for (int i = 0; i < entityCount; i++)
+        {
+            entities1[i] = _world.Spawn();
+            _world.AddComponent(entities1[i], new TestPosition { X = i, Y = i * 2, Z = 0 });
+            _world.AddComponent(entities1[i], new TestVelocity { X = 1, Y = 1, Z = 0 });
+        }
+
+        using var jobPool = new JobWorkerPool(2);
+        var jobSchedule = SystemSchedule.Create(_world)
+            .Add<TestMovementSystem>()
+            .Add<TestGravitySystem>()
+            .Build(new JobWaveScheduler(jobPool));
+
+        jobSchedule.Run();
+        var jobPositions = new TestPosition[entityCount];
+        for (int i = 0; i < entityCount; i++)
+            jobPositions[i] = _world.GetComponent<TestPosition>(entities1[i]);
+
+        // Reset and run with WorkStealingWaveScheduler
+        _world.Clear();
+        var entities2 = new Entity[entityCount];
+        for (int i = 0; i < entityCount; i++)
+        {
+            entities2[i] = _world.Spawn();
+            _world.AddComponent(entities2[i], new TestPosition { X = i, Y = i * 2, Z = 0 });
+            _world.AddComponent(entities2[i], new TestVelocity { X = 1, Y = 1, Z = 0 });
+        }
+
+        using var wsPool = new WorkStealingPool(2);
+        var wsSchedule = SystemSchedule.Create(_world)
+            .Add<TestMovementSystem>()
+            .Add<TestGravitySystem>()
+            .Build(new WorkStealingWaveScheduler(wsPool));
+
+        wsSchedule.Run();
+
+        for (int i = 0; i < entityCount; i++)
+        {
+            var wsPos = _world.GetComponent<TestPosition>(entities2[i]);
+            await Assert.That(wsPos.X).IsEqualTo(jobPositions[i].X);
+            await Assert.That(wsPos.Y).IsEqualTo(jobPositions[i].Y);
+        }
+    }
+}

--- a/src/Paradise.ECS.Jobs/JobWaveScheduler.cs
+++ b/src/Paradise.ECS.Jobs/JobWaveScheduler.cs
@@ -1,0 +1,28 @@
+namespace Paradise.ECS;
+
+/// <summary>
+/// Executes work items in parallel using a <see cref="JobWorkerPool"/>.
+/// Persistent worker threads eliminate per-wave scheduling overhead.
+/// Does NOT own the pool — the caller manages pool lifetime separately.
+/// </summary>
+public sealed class JobWaveScheduler : IWaveScheduler
+{
+    private readonly JobWorkerPool _pool;
+
+    /// <summary>
+    /// Initializes a new <see cref="JobWaveScheduler"/> backed by the specified worker pool.
+    /// </summary>
+    /// <param name="pool">The worker pool to dispatch work items to. Must outlive this scheduler.</param>
+    public JobWaveScheduler(JobWorkerPool pool)
+    {
+        _pool = pool;
+    }
+
+    /// <inheritdoc/>
+    public void Execute<TMask, TConfig>(IReadOnlyList<WorkItem<TMask, TConfig>> items)
+        where TMask : unmanaged, IBitSet<TMask>
+        where TConfig : IConfig, new()
+    {
+        _pool.ExecuteWork(items);
+    }
+}

--- a/src/Paradise.ECS.Jobs/JobWorkerPool.cs
+++ b/src/Paradise.ECS.Jobs/JobWorkerPool.cs
@@ -124,7 +124,19 @@ public sealed class JobWorkerPool : IDisposable
                 case <= 0:
                     return;
                 case 1:
-                    items[0].Invoke();
+                    // Wrap single-item exceptions in AggregateException so the
+                    // exception shape is consistent with the multi-item path
+                    // (documented in this method's <exception> tag). Otherwise
+                    // callers writing `catch (AggregateException)` would silently
+                    // miss exceptions thrown from one-item waves.
+                    try
+                    {
+                        items[0].Invoke();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new AggregateException(ex);
+                    }
                     return;
             }
 

--- a/src/Paradise.ECS.Jobs/JobWorkerPool.cs
+++ b/src/Paradise.ECS.Jobs/JobWorkerPool.cs
@@ -1,0 +1,270 @@
+using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+
+namespace Paradise.ECS;
+
+/// <summary>
+/// Persistent worker thread pool for parallel job execution.
+/// Maintains a fixed set of background threads that sleep between waves,
+/// eliminating per-wave thread startup overhead compared to <see cref="System.Threading.Tasks.Parallel"/>.
+/// The main (calling) thread participates in work processing for N+1 total parallelism.
+/// </summary>
+public sealed class JobWorkerPool : IDisposable
+{
+    /// <summary>
+    /// Number of work items claimed per atomic operation to reduce contention.
+    /// </summary>
+    private const int BatchSize = 8;
+
+    private const int StateIdle = 0;
+    private const int StateRunning = 1;
+    private const int StateDisposing = 2;
+    private const int StateDisposed = 3;
+
+    /// <summary>
+    /// Cache-line padded counters to prevent false sharing between threads.
+    /// NextWorkIndex and RemainingItems are on separate 64-byte cache lines.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = 128)]
+    private struct PaddedCounters
+    {
+        [FieldOffset(0)]
+        public int NextWorkIndex;
+
+        [FieldOffset(64)]
+        public int RemainingItems;
+    }
+
+    private readonly Thread[] _workers;
+    private readonly int _workerCount;
+
+    // Per-wave state
+    private Action<int>? _invoker;
+    private int _itemCount;
+    private PaddedCounters _counters;
+    private ConcurrentQueue<ExceptionDispatchInfo>? _exceptions;
+
+    // Synchronization
+    private readonly ManualResetEventSlim _workAvailable = new(false);
+    private readonly ManualResetEventSlim _workComplete = new(false);
+    private volatile bool _shutdown;
+    private int _state;
+
+    // Cached adapter for zero-allocation item dispatch
+    private object? _cachedAdapter;
+
+    /// <summary>
+    /// Gets the number of worker threads (excludes the main thread).
+    /// </summary>
+    public int WorkerCount => _workerCount;
+
+    /// <summary>
+    /// Initializes a new <see cref="JobWorkerPool"/> with the specified number of worker threads.
+    /// </summary>
+    /// <param name="workerCount">
+    /// Number of background worker threads. Defaults to <c>Environment.ProcessorCount - 1</c> (minimum 1).
+    /// The calling thread also participates in work, so total parallelism is <paramref name="workerCount"/> + 1.
+    /// </param>
+    public JobWorkerPool(int workerCount = -1)
+    {
+        _workerCount = workerCount < 0
+            ? Math.Max(1, Environment.ProcessorCount - 1)
+            : Math.Max(1, workerCount);
+
+        _workers = new Thread[_workerCount];
+        for (int i = 0; i < _workerCount; i++)
+        {
+            var worker = new Thread(WorkerLoop)
+            {
+                Name = $"Paradise.ECS Worker {i}",
+                IsBackground = true,
+            };
+            _workers[i] = worker;
+            worker.Start();
+        }
+    }
+
+    /// <summary>
+    /// Distributes work items across all threads (workers + main).
+    /// Blocks until all items are processed. Each item is processed exactly once.
+    /// If any work item throws, all exceptions are captured and rethrown as an <see cref="AggregateException"/>
+    /// after all items complete. The pool remains usable after an exception.
+    /// </summary>
+    /// <typeparam name="T">The work item type implementing <see cref="IWorkItem"/>.</typeparam>
+    /// <param name="items">The work items to process.</param>
+    /// <exception cref="ObjectDisposedException">The pool has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The pool is already executing work (reentrant call).</exception>
+    /// <exception cref="AggregateException">One or more work items threw exceptions.</exception>
+    public void ExecuteWork<T>(IReadOnlyList<T> items) where T : IWorkItem
+    {
+        // State machine: Idle → Running
+        var previousState = Interlocked.CompareExchange(ref _state, StateRunning, StateIdle);
+        switch (previousState)
+        {
+            case StateRunning:
+                throw new InvalidOperationException("JobWorkerPool.ExecuteWork is not reentrant. A concurrent call is already in progress.");
+            case StateDisposing:
+            case StateDisposed:
+                throw new ObjectDisposedException(nameof(JobWorkerPool));
+        }
+
+        try
+        {
+            switch (items.Count)
+            {
+                case <= 0:
+                    return;
+                case 1:
+                    items[0].Invoke();
+                    return;
+            }
+
+            var adapter = _cachedAdapter as ItemsAdapter<T>;
+            if (adapter == null)
+            {
+                adapter = new ItemsAdapter<T>();
+                _cachedAdapter = adapter;
+            }
+
+            adapter.Items = items;
+            try
+            {
+                DistributeAndProcess(items.Count, adapter.Invoker);
+            }
+            finally
+            {
+                adapter.Items = null!;
+            }
+        }
+        finally
+        {
+            // Running → Idle (allow next call or disposal)
+            Interlocked.CompareExchange(ref _state, StateIdle, StateRunning);
+        }
+    }
+
+    private void DistributeAndProcess(int count, Action<int> invoker)
+    {
+        // Setup shared state before waking workers
+        _invoker = invoker;
+        _itemCount = count;
+        _counters.NextWorkIndex = 0;
+        _counters.RemainingItems = count;
+        _exceptions = null;
+
+        // Reset completion signal, then wake workers (memory fence via Set)
+        _workComplete.Reset();
+        _workAvailable.Set();
+
+        // Main thread participates in draining work
+        DrainWork();
+
+        // Wait for all items to complete (may already be set if main finished last)
+        _workComplete.Wait();
+
+        // Reset for next wave — workers will block on Wait() again
+        _workAvailable.Reset();
+        _invoker = null;
+
+        // Rethrow captured exceptions
+        if (_exceptions is { IsEmpty: false })
+        {
+            throw new AggregateException(_exceptions.Select(e => e.SourceException));
+        }
+    }
+
+    private void DrainWork()
+    {
+        while (true)
+        {
+            int start = Interlocked.Add(ref _counters.NextWorkIndex, BatchSize) - BatchSize;
+            if (start >= _itemCount)
+                return;
+
+            int end = Math.Min(start + BatchSize, _itemCount);
+            int batchCount = end - start;
+
+            for (int i = start; i < end; i++)
+            {
+                try
+                {
+                    _invoker!(i);
+                }
+                catch (Exception ex)
+                {
+                    var queue = _exceptions;
+                    if (queue == null)
+                    {
+                        Interlocked.CompareExchange(ref _exceptions, new ConcurrentQueue<ExceptionDispatchInfo>(), null);
+                        queue = _exceptions;
+                    }
+                    queue!.Enqueue(ExceptionDispatchInfo.Capture(ex));
+                }
+            }
+
+            if (Interlocked.Add(ref _counters.RemainingItems, -batchCount) <= 0)
+            {
+                _workComplete.Set();
+                return;
+            }
+        }
+    }
+
+    private void WorkerLoop()
+    {
+        while (true)
+        {
+            _workAvailable.Wait();
+
+            if (_shutdown)
+                return;
+
+            DrainWork();
+        }
+    }
+
+    /// <summary>
+    /// Shuts down all worker threads and releases resources.
+    /// Blocks until all workers have terminated. If work is currently executing,
+    /// waits for it to complete before shutting down.
+    /// </summary>
+    public void Dispose()
+    {
+        // Attempt Idle → Disposing, spin-wait if Running
+        while (true)
+        {
+            var current = Interlocked.CompareExchange(ref _state, StateDisposing, StateIdle);
+            if (current == StateIdle)
+                break; // Successfully transitioned to Disposing
+            if (current is StateDisposing or StateDisposed)
+                return; // Already disposing/disposed — idempotent
+            // StateRunning: work in progress — spin-wait for it to finish
+            Thread.SpinWait(1);
+        }
+
+        _shutdown = true;
+        _workAvailable.Set();
+
+        for (int i = 0; i < _workers.Length; i++)
+            _workers[i].Join();
+
+        _workAvailable.Dispose();
+        _workComplete.Dispose();
+
+        Volatile.Write(ref _state, StateDisposed);
+    }
+
+    private sealed class ItemsAdapter<T> where T : IWorkItem
+    {
+        public IReadOnlyList<T> Items = null!;
+        public readonly Action<int> Invoker;
+
+        public ItemsAdapter()
+        {
+            Invoker = Invoke;
+        }
+
+        private void Invoke(int index) => Items[index].Invoke();
+    }
+}

--- a/src/Paradise.ECS.Jobs/JobWorkerPool.cs
+++ b/src/Paradise.ECS.Jobs/JobWorkerPool.cs
@@ -45,6 +45,14 @@ public sealed class JobWorkerPool : IDisposable
     private PaddedCounters _counters;
     private ConcurrentQueue<ExceptionDispatchInfo>? _exceptions;
 
+    // One-shot latch flipped by the single thread that performs end-of-wave
+    // bookkeeping (reset _workAvailable, then set _workComplete). Reset to 0 at
+    // the start of each wave. Multiple draining threads may observe
+    // RemainingItems <= 0 simultaneously; the latch ensures exactly one of them
+    // does the cleanup, preventing a stray late Reset() from clobbering the
+    // next wave's Set() on _workAvailable.
+    private int _waveCompleteLatch;
+
     // Synchronization
     private readonly ManualResetEventSlim _workAvailable = new(false);
     private readonly ManualResetEventSlim _workComplete = new(false);
@@ -152,19 +160,25 @@ public sealed class JobWorkerPool : IDisposable
         _counters.NextWorkIndex = 0;
         _counters.RemainingItems = count;
         _exceptions = null;
+        Volatile.Write(ref _waveCompleteLatch, 0);
 
-        // Reset completion signal, then wake workers (memory fence via Set)
+        // Reset completion signal, then wake workers. The Set publishes all the
+        // shared-state writes above (memory fence). _workAvailable is guaranteed
+        // to be in the reset state here: the previous wave's completer (whichever
+        // draining thread won the latch) called Reset() BEFORE Setting
+        // _workComplete, so by the time main returned from _workComplete.Wait()
+        // last wave, _workAvailable was already false.
         _workComplete.Reset();
         _workAvailable.Set();
 
         // Main thread participates in draining work
         DrainWork();
 
-        // Wait for all items to complete (may already be set if main finished last)
+        // Wait for all items to complete. The completer worker has already reset
+        // _workAvailable, so any worker looping back into WorkerLoop will block
+        // on Wait() until the next wave's Set() — no busy re-entry into DrainWork.
         _workComplete.Wait();
 
-        // Reset for next wave — workers will block on Wait() again
-        _workAvailable.Reset();
         _invoker = null;
 
         // Rethrow captured exceptions
@@ -205,7 +219,20 @@ public sealed class JobWorkerPool : IDisposable
 
             if (Interlocked.Add(ref _counters.RemainingItems, -batchCount) <= 0)
             {
-                _workComplete.Set();
+                // Multiple draining threads may observe RemainingItems <= 0 (the
+                // last batch may straddle batchSize boundaries, dropping the
+                // counter below zero from several threads at once). Use a
+                // one-shot latch so exactly one thread performs the wave-end
+                // bookkeeping. Otherwise a stray late Reset() from a slower
+                // completer could clobber the next wave's _workAvailable.Set().
+                if (Interlocked.Exchange(ref _waveCompleteLatch, 1) == 0)
+                {
+                    // Reset BEFORE signaling so workers looping back to
+                    // WorkerLoop.Wait() block until the next wave, instead of
+                    // re-entering DrainWork on a still-set _workAvailable.
+                    _workAvailable.Reset();
+                    _workComplete.Set();
+                }
                 return;
             }
         }

--- a/src/Paradise.ECS.Jobs/Paradise.ECS.Jobs.csproj
+++ b/src/Paradise.ECS.Jobs/Paradise.ECS.Jobs.csproj
@@ -3,6 +3,13 @@
   <Import Project="..\Paradise.ECS.Common.props" />
 
   <PropertyGroup>
+    <!--
+      Single-target net10.0 is intentional. All Paradise.ECS.* runtime projects
+      target net10.0 only (see Paradise.ECS.Common.props for the rationale).
+      The netstandard2.1;net10.0 dual-target convention applies to Paradise.BT
+      and Paradise.BLOB but NOT to the ECS layer. Do not change to dual-target
+      without aligning every sibling Paradise.ECS.* project first.
+    -->
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/Paradise.ECS.Jobs/Paradise.ECS.Jobs.csproj
+++ b/src/Paradise.ECS.Jobs/Paradise.ECS.Jobs.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Paradise.ECS.Common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Paradise.ECS.Jobs.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paradise.ECS\Paradise.ECS.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Paradise.ECS" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paradise.ECS.Jobs/WorkStealingDeque.cs
+++ b/src/Paradise.ECS.Jobs/WorkStealingDeque.cs
@@ -1,0 +1,151 @@
+namespace Paradise.ECS;
+
+/// <summary>
+/// Bounded lock-free Chase-Lev work-stealing deque.
+/// The owner pushes/pops from the bottom (LIFO for cache locality),
+/// while thieves steal from the top (FIFO for fairness).
+/// </summary>
+internal sealed class WorkStealingDeque
+{
+    private int[] _buffer;
+    private int _top;
+    private int _bottom;
+
+    /// <summary>
+    /// Initializes a new deque with the specified initial capacity.
+    /// </summary>
+    /// <param name="capacity">Initial capacity (must be power of 2).</param>
+    public WorkStealingDeque(int capacity = 64)
+    {
+        _buffer = new int[RoundUpPowerOf2(capacity)];
+    }
+
+    /// <summary>
+    /// Gets the current number of items in the deque (approximate, for diagnostics).
+    /// </summary>
+    public int Count => Math.Max(0, _bottom - _top);
+
+    /// <summary>
+    /// Owner pushes an item to the bottom of the deque.
+    /// Only the owning thread may call this.
+    /// </summary>
+    /// <param name="item">The work item index to push.</param>
+    public void PushBottom(int item)
+    {
+        int b = _bottom;
+        int t = Volatile.Read(ref _top);
+        int size = b - t;
+
+        if (size >= _buffer.Length)
+            Grow(b, t);
+
+        _buffer[b & (_buffer.Length - 1)] = item;
+        Volatile.Write(ref _bottom, b + 1);
+    }
+
+    /// <summary>
+    /// Owner pops an item from the bottom of the deque (LIFO).
+    /// Only the owning thread may call this.
+    /// </summary>
+    /// <returns>The work item index, or -1 if the deque is empty.</returns>
+    public int PopBottom()
+    {
+        int b = _bottom - 1;
+        _bottom = b;
+        // StoreLoad fence: _bottom write must be visible to stealers before we read _top.
+        // Volatile.Read is insufficient here — it only provides acquire (LoadLoad/LoadStore),
+        // but we need the preceding store to _bottom ordered before the subsequent load of _top.
+        Thread.MemoryBarrier();
+        int t = _top;
+
+        if (b - t >= 0)
+        {
+            // Non-empty
+            int item = _buffer[b & (_buffer.Length - 1)];
+            if (t == b)
+            {
+                // Last element — race with stealers
+                if (Interlocked.CompareExchange(ref _top, t + 1, t) != t)
+                {
+                    // Lost race to a stealer
+                    _bottom = t + 1;
+                    return -1;
+                }
+                _bottom = t + 1;
+            }
+            return item;
+        }
+
+        // Empty
+        _bottom = t;
+        return -1;
+    }
+
+    /// <summary>
+    /// Thief steals an item from the top of the deque (FIFO).
+    /// Any thread may call this concurrently.
+    /// </summary>
+    /// <returns>The work item index, or -1 if the deque is empty or contention occurred.</returns>
+    public int Steal()
+    {
+        int t = Volatile.Read(ref _top);
+        // Acquire on _top ensures we read _top before _bottom (LoadLoad ordering).
+        // Plain read of _bottom is intentional per Chase-Lev: a stale value only causes
+        // a missed steal opportunity, and the CAS on _top guarantees correctness.
+        int b = _bottom;
+
+        if (b - t <= 0)
+            return -1; // Empty
+
+        // Cache buffer and length to avoid race with Grow()
+        var buffer = _buffer;
+        int item = buffer[t & (buffer.Length - 1)];
+
+        if (Interlocked.CompareExchange(ref _top, t + 1, t) != t)
+            return -1; // Lost race
+
+        return item;
+    }
+
+    /// <summary>
+    /// Resets the deque for reuse across waves without reallocation.
+    /// Only call when no threads are accessing the deque.
+    /// Resetting to 0 prevents index wrap-around issues within a single wave.
+    /// </summary>
+    /// <param name="capacity">Optional new minimum capacity.</param>
+    public void Reset(int capacity = 0)
+    {
+        _top = 0;
+        _bottom = 0;
+        if (capacity > _buffer.Length)
+            _buffer = new int[RoundUpPowerOf2(capacity)];
+    }
+
+    private void Grow(int bottom, int top)
+    {
+        int oldLen = _buffer.Length;
+        int newLen = oldLen * 2;
+        var newBuf = new int[newLen];
+
+        // Use size to avoid wrap-around bugs in loop condition
+        int size = bottom - top;
+        for (int i = 0; i < size; i++)
+        {
+            int index = top + i;
+            newBuf[index & (newLen - 1)] = _buffer[index & (oldLen - 1)];
+        }
+        _buffer = newBuf;
+    }
+
+    private static int RoundUpPowerOf2(int value)
+    {
+        if (value <= 1) return 1;
+        value--;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        return value + 1;
+    }
+}

--- a/src/Paradise.ECS.Jobs/WorkStealingDeque.cs
+++ b/src/Paradise.ECS.Jobs/WorkStealingDeque.cs
@@ -97,12 +97,32 @@ internal sealed class WorkStealingDeque
         if (b - t <= 0)
             return -1; // Empty
 
-        // Cache buffer and length to avoid race with Grow()
+        // Read the buffer reference and the slot value BEFORE the CAS. This is the
+        // canonical Chase-Lev ordering (see Chase & Lev 2005; Lê et al. PPoPP'13)
+        // and it is required for correctness — NOT an optimization.
+        //
+        // Why pre-CAS:
+        //   Once our CAS succeeds, _top advances past index t. The owner is then
+        //   free to PushBottom new items, and after enough pushes the slot at
+        //   physical position (t & mask) — in either the current buffer or a
+        //   future grown buffer — can be overwritten by a wrap-around write.
+        //   Reading the slot AFTER the CAS would race that overwrite and could
+        //   return an unrelated item (corrupting work distribution).
+        //
+        // Why Grow does not break this:
+        //   Grow() allocates a new buffer, copies elements [top, bottom) into it,
+        //   then publishes _buffer = newBuf. It never mutates the old buffer.
+        //   - If we captured oldBuf before Grow(): oldBuf[t & oldMask] is frozen
+        //     (subsequent owner writes go to newBuf, not oldBuf) so our read is
+        //     valid forever.
+        //   - If we captured newBuf after Grow(): Grow ran while _top was still
+        //     t (we hadn't CAS'd), so it copied slot t into newBuf[t & newMask].
+        //     Our read is valid.
         var buffer = _buffer;
         int item = buffer[t & (buffer.Length - 1)];
 
         if (Interlocked.CompareExchange(ref _top, t + 1, t) != t)
-            return -1; // Lost race
+            return -1; // Lost race to a competing stealer or concurrent PopBottom.
 
         return item;
     }

--- a/src/Paradise.ECS.Jobs/WorkStealingDeque.cs
+++ b/src/Paradise.ECS.Jobs/WorkStealingDeque.cs
@@ -111,14 +111,19 @@ internal sealed class WorkStealingDeque
         //
         // Why Grow does not break this:
         //   Grow() allocates a new buffer, copies elements [top, bottom) into it,
-        //   then publishes _buffer = newBuf. It never mutates the old buffer.
+        //   then publishes the new reference via Volatile.Write(ref _buffer, newBuf).
+        //   It never mutates the old buffer.
         //   - If we captured oldBuf before Grow(): oldBuf[t & oldMask] is frozen
         //     (subsequent owner writes go to newBuf, not oldBuf) so our read is
         //     valid forever.
         //   - If we captured newBuf after Grow(): Grow ran while _top was still
         //     t (we hadn't CAS'd), so it copied slot t into newBuf[t & newMask].
-        //     Our read is valid.
-        var buffer = _buffer;
+        //     The Volatile.Read here pairs with Grow's Volatile.Write so on
+        //     weakly ordered architectures (notably ARM64) we cannot observe the
+        //     new buffer reference before its initializing array writes are
+        //     committed — without the pairing we could read a zero from a
+        //     not-yet-published slot.
+        var buffer = Volatile.Read(ref _buffer);
         int item = buffer[t & (buffer.Length - 1)];
 
         if (Interlocked.CompareExchange(ref _top, t + 1, t) != t)
@@ -154,7 +159,14 @@ internal sealed class WorkStealingDeque
             int index = top + i;
             newBuf[index & (newLen - 1)] = _buffer[index & (oldLen - 1)];
         }
-        _buffer = newBuf;
+        // Volatile.Write provides release semantics so a concurrent Steal that
+        // observes the new _buffer reference is guaranteed to also observe the
+        // initializing slot writes above. Plain reference store would be racy on
+        // ARM64 (weakly ordered) — a stealer could read the new array reference
+        // while the slots still appear zero. Pairs with Volatile.Read in Steal().
+        // PushBottom only reads _buffer on the owner thread that just wrote it
+        // here, so it does not need a Volatile.Read.
+        Volatile.Write(ref _buffer, newBuf);
     }
 
     private static int RoundUpPowerOf2(int value)

--- a/src/Paradise.ECS.Jobs/WorkStealingPool.cs
+++ b/src/Paradise.ECS.Jobs/WorkStealingPool.cs
@@ -171,6 +171,7 @@ public sealed class WorkStealingPool : IDisposable
     private void ProcessLane(int laneIndex)
     {
         var myDeque = _deques[laneIndex];
+        var spinner = new SpinWait();
 
         while (true)
         {
@@ -183,12 +184,22 @@ public sealed class WorkStealingPool : IDisposable
                 item = TrySteal(laneIndex);
                 if (item < 0)
                 {
-                    // No work anywhere — check if all done
+                    // No work anywhere — check if all done. Issue an explicit full
+                    // memory barrier before the read of _remainingItems: while
+                    // Interlocked.Decrement provides ordering on the writer side,
+                    // pairing it here with a barrier guarantees that on weakly
+                    // ordered architectures (notably ARM64) we observe the latest
+                    // decrement before deciding to exit. One barrier per idle spin
+                    // is acceptable cost.
+                    Thread.MemoryBarrier();
                     if (Volatile.Read(ref _remainingItems) <= 0)
                         return;
 
-                    // Yield and retry — work might still be in-flight
-                    Thread.Yield();
+                    // Adaptive backoff during true idle: SpinWait ramps from busy
+                    // spinning to Thread.Yield to Thread.Sleep(0)/Sleep(1) as the
+                    // count grows. Resets below whenever we successfully process
+                    // an item, so backoff only escalates during sustained idle.
+                    spinner.SpinOnce();
                     continue;
                 }
             }
@@ -208,6 +219,10 @@ public sealed class WorkStealingPool : IDisposable
                 }
                 queue!.Enqueue(ExceptionDispatchInfo.Capture(ex));
             }
+
+            // Reset SpinWait so backoff doesn't carry over from a prior idle stretch
+            // once we've found work again.
+            spinner.Reset();
 
             if (Interlocked.Decrement(ref _remainingItems) <= 0)
                 return;

--- a/src/Paradise.ECS.Jobs/WorkStealingPool.cs
+++ b/src/Paradise.ECS.Jobs/WorkStealingPool.cs
@@ -1,0 +1,283 @@
+using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
+
+namespace Paradise.ECS;
+
+/// <summary>
+/// Work-stealing thread pool for parallel job execution.
+/// Each worker has a per-worker Chase-Lev deque. Work is distributed round-robin
+/// at dispatch time. Workers pop from their own deque (LIFO for cache locality),
+/// then steal from neighbors when empty (FIFO for fairness).
+/// The main (calling) thread participates as lane 0 for N+1 total parallelism.
+/// </summary>
+public sealed class WorkStealingPool : IDisposable
+{
+    private const int StateIdle = 0;
+    private const int StateRunning = 1;
+    private const int StateDisposing = 2;
+    private const int StateDisposed = 3;
+
+    private readonly Thread[] _workers;
+    private readonly int _workerCount;
+    private readonly WorkStealingDeque[] _deques;
+    private readonly int _totalLanes; // workerCount + 1 (main thread = lane 0)
+
+    // Per-wave state
+    private Action<int>? _invoker;
+    private int _remainingItems;
+    private ConcurrentQueue<ExceptionDispatchInfo>? _exceptions;
+
+    // Synchronization
+    private readonly ManualResetEventSlim _workAvailable = new(false);
+    private readonly Barrier _waveBarrier;
+    private volatile bool _shutdown;
+    private int _state;
+
+    // Cached adapter for zero-allocation item dispatch
+    private object? _cachedAdapter;
+
+    /// <summary>
+    /// Gets the number of worker threads (excludes the main thread).
+    /// </summary>
+    public int WorkerCount => _workerCount;
+
+    /// <summary>
+    /// Initializes a new <see cref="WorkStealingPool"/> with the specified number of worker threads.
+    /// </summary>
+    /// <param name="workerCount">
+    /// Number of background worker threads. Defaults to <c>Environment.ProcessorCount - 1</c> (minimum 1).
+    /// The calling thread also participates in work, so total parallelism is <paramref name="workerCount"/> + 1.
+    /// </param>
+    public WorkStealingPool(int workerCount = -1)
+    {
+        _workerCount = workerCount < 0
+            ? Math.Max(1, Environment.ProcessorCount - 1)
+            : Math.Max(1, workerCount);
+
+        _totalLanes = _workerCount + 1;
+        // Post-phase action resets _workAvailable BEFORE participants are released,
+        // preventing workers from re-entering ProcessLane between waves.
+        _waveBarrier = new Barrier(_totalLanes, _ => _workAvailable.Reset());
+        _deques = new WorkStealingDeque[_totalLanes];
+        for (int i = 0; i < _totalLanes; i++)
+            _deques[i] = new WorkStealingDeque();
+
+        _workers = new Thread[_workerCount];
+        for (int i = 0; i < _workerCount; i++)
+        {
+            int laneIndex = i + 1; // lane 0 = main thread
+            var worker = new Thread(() => WorkerLoop(laneIndex))
+            {
+                Name = $"Paradise.ECS Stealer {i}",
+                IsBackground = true,
+            };
+            _workers[i] = worker;
+            worker.Start();
+        }
+    }
+
+    /// <summary>
+    /// Distributes work items across all lanes using round-robin,
+    /// then processes them with work-stealing. Blocks until all items are processed.
+    /// </summary>
+    /// <typeparam name="T">The work item type implementing <see cref="IWorkItem"/>.</typeparam>
+    /// <param name="items">The work items to process.</param>
+    /// <exception cref="ObjectDisposedException">The pool has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The pool is already executing work (reentrant call).</exception>
+    /// <exception cref="AggregateException">One or more work items threw exceptions.</exception>
+    public void ExecuteWork<T>(IReadOnlyList<T> items) where T : IWorkItem
+    {
+        // State machine: Idle → Running
+        var previousState = Interlocked.CompareExchange(ref _state, StateRunning, StateIdle);
+        switch (previousState)
+        {
+            case StateRunning:
+                throw new InvalidOperationException("WorkStealingPool.ExecuteWork is not reentrant. A concurrent call is already in progress.");
+            case StateDisposing:
+            case StateDisposed:
+                throw new ObjectDisposedException(nameof(WorkStealingPool));
+        }
+
+        try
+        {
+            switch (items.Count)
+            {
+                case <= 0:
+                    return;
+                case 1:
+                    items[0].Invoke();
+                    return;
+            }
+
+            var adapter = _cachedAdapter as ItemsAdapter<T>;
+            if (adapter == null)
+            {
+                adapter = new ItemsAdapter<T>();
+                _cachedAdapter = adapter;
+            }
+
+            adapter.Items = items;
+            try
+            {
+                DistributeAndProcess(items.Count, adapter.Invoker);
+            }
+            finally
+            {
+                adapter.Items = null!;
+            }
+        }
+        finally
+        {
+            // Running → Idle
+            Interlocked.CompareExchange(ref _state, StateIdle, StateRunning);
+        }
+    }
+
+    private void DistributeAndProcess(int count, Action<int> invoker)
+    {
+        // Setup shared state
+        _invoker = invoker;
+        _remainingItems = count;
+        _exceptions = null;
+
+        // Reset deques and distribute work round-robin
+        for (int i = 0; i < _totalLanes; i++)
+            _deques[i].Reset(count / _totalLanes + 1);
+
+        for (int i = 0; i < count; i++)
+            _deques[i % _totalLanes].PushBottom(i);
+
+        // Wake workers
+        _workAvailable.Set();
+
+        // Main thread processes lane 0
+        ProcessLane(0);
+
+        // Wait for all workers to finish ProcessLane via barrier.
+        // This guarantees no worker is still accessing deques or shared state
+        // before the next wave begins.
+        _waveBarrier.SignalAndWait();
+
+        // All lanes done — _workAvailable was reset by the barrier's post-phase action
+        _invoker = null;
+
+        // Rethrow captured exceptions
+        if (_exceptions is { IsEmpty: false })
+        {
+            throw new AggregateException(_exceptions.Select(e => e.SourceException));
+        }
+    }
+
+    private void ProcessLane(int laneIndex)
+    {
+        var myDeque = _deques[laneIndex];
+
+        while (true)
+        {
+            // Try own deque first (LIFO)
+            int item = myDeque.PopBottom();
+
+            if (item < 0)
+            {
+                // Try stealing from neighbors
+                item = TrySteal(laneIndex);
+                if (item < 0)
+                {
+                    // No work anywhere — check if all done
+                    if (Volatile.Read(ref _remainingItems) <= 0)
+                        return;
+
+                    // Yield and retry — work might still be in-flight
+                    Thread.Yield();
+                    continue;
+                }
+            }
+
+            // Execute the item
+            try
+            {
+                _invoker!(item);
+            }
+            catch (Exception ex)
+            {
+                var queue = _exceptions;
+                if (queue == null)
+                {
+                    Interlocked.CompareExchange(ref _exceptions, new ConcurrentQueue<ExceptionDispatchInfo>(), null);
+                    queue = _exceptions;
+                }
+                queue!.Enqueue(ExceptionDispatchInfo.Capture(ex));
+            }
+
+            if (Interlocked.Decrement(ref _remainingItems) <= 0)
+                return;
+        }
+    }
+
+    private int TrySteal(int myLane)
+    {
+        // Round-robin steal from other lanes
+        for (int offset = 1; offset < _totalLanes; offset++)
+        {
+            int victim = (myLane + offset) % _totalLanes;
+            int item = _deques[victim].Steal();
+            if (item >= 0)
+                return item;
+        }
+        return -1;
+    }
+
+    private void WorkerLoop(int laneIndex)
+    {
+        while (true)
+        {
+            _workAvailable.Wait();
+
+            if (_shutdown)
+                return;
+
+            ProcessLane(laneIndex);
+            _waveBarrier.SignalAndWait();
+        }
+    }
+
+    /// <summary>
+    /// Shuts down all worker threads and releases resources.
+    /// </summary>
+    public void Dispose()
+    {
+        while (true)
+        {
+            var current = Interlocked.CompareExchange(ref _state, StateDisposing, StateIdle);
+            if (current == StateIdle)
+                break;
+            if (current is StateDisposing or StateDisposed)
+                return;
+            Thread.SpinWait(1);
+        }
+
+        _shutdown = true;
+        _workAvailable.Set();
+
+        for (int i = 0; i < _workers.Length; i++)
+            _workers[i].Join();
+
+        _workAvailable.Dispose();
+        _waveBarrier.Dispose();
+
+        Volatile.Write(ref _state, StateDisposed);
+    }
+
+    private sealed class ItemsAdapter<T> where T : IWorkItem
+    {
+        public IReadOnlyList<T> Items = null!;
+        public readonly Action<int> Invoker;
+
+        public ItemsAdapter()
+        {
+            Invoker = Invoke;
+        }
+
+        private void Invoke(int index) => Items[index].Invoke();
+    }
+}

--- a/src/Paradise.ECS.Jobs/WorkStealingPool.cs
+++ b/src/Paradise.ECS.Jobs/WorkStealingPool.cs
@@ -105,7 +105,19 @@ public sealed class WorkStealingPool : IDisposable
                 case <= 0:
                     return;
                 case 1:
-                    items[0].Invoke();
+                    // Wrap single-item exceptions in AggregateException so the
+                    // exception shape is consistent with the multi-item path
+                    // (documented in this method's <exception> tag). Otherwise
+                    // callers writing `catch (AggregateException)` would silently
+                    // miss exceptions thrown from one-item waves.
+                    try
+                    {
+                        items[0].Invoke();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new AggregateException(ex);
+                    }
                     return;
             }
 
@@ -184,14 +196,12 @@ public sealed class WorkStealingPool : IDisposable
                 item = TrySteal(laneIndex);
                 if (item < 0)
                 {
-                    // No work anywhere — check if all done. Issue an explicit full
-                    // memory barrier before the read of _remainingItems: while
-                    // Interlocked.Decrement provides ordering on the writer side,
-                    // pairing it here with a barrier guarantees that on weakly
-                    // ordered architectures (notably ARM64) we observe the latest
-                    // decrement before deciding to exit. One barrier per idle spin
-                    // is acceptable cost.
-                    Thread.MemoryBarrier();
+                    // No work anywhere — check if all done. Volatile.Read provides
+                    // the acquire fence that pairs with the Interlocked.Decrement
+                    // release on the writer side, so the observed value reflects
+                    // every decrement that happened-before any preceding empty
+                    // observation by PopBottom/TrySteal. No additional explicit
+                    // memory barrier is required.
                     if (Volatile.Read(ref _remainingItems) <= 0)
                         return;
 

--- a/src/Paradise.ECS.Jobs/WorkStealingWaveScheduler.cs
+++ b/src/Paradise.ECS.Jobs/WorkStealingWaveScheduler.cs
@@ -1,0 +1,29 @@
+namespace Paradise.ECS;
+
+/// <summary>
+/// Executes work items using a <see cref="WorkStealingPool"/>.
+/// Per-worker Chase-Lev deques provide better load balancing than
+/// the atomic counter approach of <see cref="JobWaveScheduler"/>.
+/// Does NOT own the pool — the caller manages pool lifetime separately.
+/// </summary>
+public sealed class WorkStealingWaveScheduler : IWaveScheduler
+{
+    private readonly WorkStealingPool _pool;
+
+    /// <summary>
+    /// Initializes a new <see cref="WorkStealingWaveScheduler"/> backed by the specified pool.
+    /// </summary>
+    /// <param name="pool">The work-stealing pool to dispatch work items to. Must outlive this scheduler.</param>
+    public WorkStealingWaveScheduler(WorkStealingPool pool)
+    {
+        _pool = pool;
+    }
+
+    /// <inheritdoc/>
+    public void Execute<TMask, TConfig>(IReadOnlyList<WorkItem<TMask, TConfig>> items)
+        where TMask : unmanaged, IBitSet<TMask>
+        where TConfig : IConfig, new()
+    {
+        _pool.ExecuteWork(items);
+    }
+}

--- a/src/Paradise.ECS/Paradise.ECS.csproj
+++ b/src/Paradise.ECS/Paradise.ECS.csproj
@@ -11,6 +11,8 @@
     <InternalsVisibleTo Include="Paradise.ECS.Tag" />
     <InternalsVisibleTo Include="Paradise.ECS.Concurrent" />
     <InternalsVisibleTo Include="Paradise.ECS.Concurrent.Test" />
+    <InternalsVisibleTo Include="Paradise.ECS.Jobs" />
+    <InternalsVisibleTo Include="Paradise.ECS.Jobs.Test" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Paradise.ECS/Systems/WaveScheduler.cs
+++ b/src/Paradise.ECS/Systems/WaveScheduler.cs
@@ -1,12 +1,23 @@
 namespace Paradise.ECS;
 
 /// <summary>
+/// A self-contained unit of work that can be executed by a thread pool.
+/// </summary>
+public interface IWorkItem
+{
+    /// <summary>
+    /// Executes this work item.
+    /// </summary>
+    void Invoke();
+}
+
+/// <summary>
 /// Represents a unit of work within a system execution wave.
 /// Stores all invocation data inline to avoid closure allocations.
 /// </summary>
 /// <typeparam name="TMask">The component mask type implementing IBitSet.</typeparam>
 /// <typeparam name="TConfig">The world configuration type.</typeparam>
-public readonly struct WorkItem<TMask, TConfig>
+public readonly struct WorkItem<TMask, TConfig> : IWorkItem
     where TMask : unmanaged, IBitSet<TMask>
     where TConfig : IConfig, new()
 {
@@ -55,6 +66,13 @@ public readonly struct WorkItem<TMask, TConfig>
 /// thread pools with data affinity, or custom work-stealing schedulers).
 /// ECB playback is managed by <see cref="SystemSchedule{TMask,TConfig}"/> after execution completes.
 /// </summary>
+/// <remarks>
+/// The <c>items</c> parameter uses <see cref="IReadOnlyList{T}"/> rather than a concrete type
+/// (e.g., <c>List&lt;T&gt;</c>) or <c>Span&lt;T&gt;</c> to keep the interface decoupled from
+/// implementation details. The interface dispatch overhead is amortized: <c>Execute</c> is called
+/// once per wave (not per chunk), so the cost of virtual calls on <c>Count</c> and <c>this[int]</c>
+/// is dwarfed by the actual system execution work within each item.
+/// </remarks>
 public interface IWaveScheduler
 {
     /// <summary>


### PR DESCRIPTION
## Summary
- port the ParadiseECS job system from ParadiseEngine/ParadiseECS#56 into ParadiseEngine
- add Paradise.ECS.Jobs and Paradise.ECS.Jobs.Test with JobWorkerPool, WorkStealingPool, and wave schedulers
- wire IWorkItem, benchmarks, and solution/project references into this repo's ECS layout

## Source
- Original PR: https://github.com/ParadiseEngine/ParadiseECS/pull/56

## Verification
- dotnet build ParadiseEngine.slnx -p:TreatWarningsAsErrors=true
- dotnet test --solution ParadiseEngine.slnx --no-build --output normal