### PR TITLE
[dev] Add Paradise.Rendering data-contract scaffold

### DIFF
--- a/ParadiseEngine.slnx
+++ b/ParadiseEngine.slnx
@@ -18,6 +18,7 @@
     <Project Path="src/Paradise.ECS.Concurrent/Paradise.ECS.Concurrent.csproj" />
     <Project Path="src/Paradise.ECS.Tag/Paradise.ECS.Tag.csproj" />
     <Project Path="src/Paradise.ECS/Paradise.ECS.csproj" />
+    <Project Path="src/Paradise.Rendering/Paradise.Rendering.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="src/Paradise.BLOB.Test/Paradise.BLOB.Test.csproj" />
@@ -27,5 +28,6 @@
     <Project Path="src/Paradise.ECS.CoyoteTest/Paradise.ECS.CoyoteTest.csproj" />
     <Project Path="src/Paradise.ECS.Generators.Test/Paradise.ECS.Generators.Test.csproj" />
     <Project Path="src/Paradise.ECS.Test/Paradise.ECS.Test.csproj" />
+    <Project Path="src/Paradise.Rendering.Test/Paradise.Rendering.Test.csproj" />
   </Folder>
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
     <!-- Runtime helpers -->
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <!-- Testing (TUnit with Native AOT support) -->
     <PackageVersion Include="TUnit" Version="1.11.16" />
     <PackageVersion Include="Microsoft.Coyote.Test" Version="1.7.11" />

--- a/src/Paradise.Rendering.Test/ColorRgbaTests.cs
+++ b/src/Paradise.Rendering.Test/ColorRgbaTests.cs
@@ -1,0 +1,50 @@
+namespace Paradise.Rendering.Test;
+
+public class ColorRgbaTests
+{
+    [Test]
+    public async Task black_is_opaque_zero_rgb()
+    {
+        var c = ColorRgba.Black;
+        await Assert.That(c.R).IsEqualTo(0f);
+        await Assert.That(c.G).IsEqualTo(0f);
+        await Assert.That(c.B).IsEqualTo(0f);
+        await Assert.That(c.A).IsEqualTo(1f);
+    }
+
+    [Test]
+    public async Task white_is_opaque_one_rgb()
+    {
+        var c = ColorRgba.White;
+        await Assert.That(c.R).IsEqualTo(1f);
+        await Assert.That(c.G).IsEqualTo(1f);
+        await Assert.That(c.B).IsEqualTo(1f);
+        await Assert.That(c.A).IsEqualTo(1f);
+    }
+
+    [Test]
+    public async Task transparent_is_zero_alpha()
+    {
+        await Assert.That(ColorRgba.Transparent.A).IsEqualTo(0f);
+    }
+
+    [Test]
+    public async Task cornflower_blue_matches_xna_classic_constant()
+    {
+        var c = ColorRgba.CornflowerBlue;
+        await Assert.That(c.R).IsEqualTo(0.392f);
+        await Assert.That(c.G).IsEqualTo(0.584f);
+        await Assert.That(c.B).IsEqualTo(0.929f);
+        await Assert.That(c.A).IsEqualTo(1f);
+    }
+
+    [Test]
+    public async Task color_equality_is_componentwise()
+    {
+        var a = new ColorRgba(0.1f, 0.2f, 0.3f, 0.4f);
+        var b = new ColorRgba(0.1f, 0.2f, 0.3f, 0.4f);
+        var c = new ColorRgba(0.1f, 0.2f, 0.3f, 0.5f);
+        await Assert.That(a == b).IsTrue();
+        await Assert.That(a != c).IsTrue();
+    }
+}

--- a/src/Paradise.Rendering.Test/HandleTests.cs
+++ b/src/Paradise.Rendering.Test/HandleTests.cs
@@ -1,0 +1,94 @@
+namespace Paradise.Rendering.Test;
+
+public class HandleTests
+{
+    [Test]
+    public async Task buffer_handle_default_is_invalid()
+    {
+        var h = default(BufferHandle);
+        await Assert.That(h.IsValid).IsFalse();
+        await Assert.That(h).IsEqualTo(BufferHandle.Invalid);
+    }
+
+    [Test]
+    public async Task texture_handle_default_is_invalid()
+    {
+        var h = default(TextureHandle);
+        await Assert.That(h.IsValid).IsFalse();
+        await Assert.That(h).IsEqualTo(TextureHandle.Invalid);
+    }
+
+    [Test]
+    public async Task sampler_handle_default_is_invalid()
+    {
+        var h = default(SamplerHandle);
+        await Assert.That(h.IsValid).IsFalse();
+        await Assert.That(h).IsEqualTo(SamplerHandle.Invalid);
+    }
+
+    [Test]
+    public async Task pipeline_handle_default_is_invalid()
+    {
+        var h = default(PipelineHandle);
+        await Assert.That(h.IsValid).IsFalse();
+        await Assert.That(h).IsEqualTo(PipelineHandle.Invalid);
+    }
+
+    [Test]
+    public async Task shader_handle_default_is_invalid()
+    {
+        var h = default(ShaderHandle);
+        await Assert.That(h.IsValid).IsFalse();
+        await Assert.That(h).IsEqualTo(ShaderHandle.Invalid);
+    }
+
+    [Test]
+    public async Task render_view_handle_default_is_invalid()
+    {
+        var h = default(RenderViewHandle);
+        await Assert.That(h.IsValid).IsFalse();
+        await Assert.That(h).IsEqualTo(RenderViewHandle.Invalid);
+    }
+
+    [Test]
+    public async Task buffer_handle_with_nonzero_generation_is_valid()
+    {
+        var h = new BufferHandle(7, 1);
+        await Assert.That(h.IsValid).IsTrue();
+        await Assert.That(h.Index).IsEqualTo(7u);
+        await Assert.That(h.Generation).IsEqualTo(1u);
+    }
+
+    [Test]
+    public async Task handles_with_same_index_and_generation_are_equal()
+    {
+        var a = new BufferHandle(3, 2);
+        var b = new BufferHandle(3, 2);
+        await Assert.That(a).IsEqualTo(b);
+        await Assert.That(a == b).IsTrue();
+        await Assert.That(a != b).IsFalse();
+        await Assert.That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
+    }
+
+    [Test]
+    public async Task handles_with_different_index_or_generation_are_unequal()
+    {
+        var a = new BufferHandle(1, 2);
+        var b = new BufferHandle(1, 3);
+        var c = new BufferHandle(2, 2);
+        await Assert.That(a == b).IsFalse();
+        await Assert.That(a == c).IsFalse();
+        await Assert.That(a != b).IsTrue();
+    }
+
+    [Test]
+    public async Task handles_of_different_kinds_have_independent_default_invalid()
+    {
+        await Assert.That(default(BufferHandle).IsValid).IsFalse();
+        await Assert.That(default(TextureHandle).IsValid).IsFalse();
+        await Assert.That(default(SamplerHandle).IsValid).IsFalse();
+        await Assert.That(default(PipelineHandle).IsValid).IsFalse();
+        await Assert.That(default(ShaderHandle).IsValid).IsFalse();
+        await Assert.That(default(RenderViewHandle).IsValid).IsFalse();
+    }
+}

--- a/src/Paradise.Rendering.Test/HandleTests.cs
+++ b/src/Paradise.Rendering.Test/HandleTests.cs
@@ -91,4 +91,17 @@ public class HandleTests
         await Assert.That(default(ShaderHandle).IsValid).IsFalse();
         await Assert.That(default(RenderViewHandle).IsValid).IsFalse();
     }
+
+    [Test]
+    public async Task handles_reserve_sixteen_bytes_for_future_packing()
+    {
+        // Each handle is sized to 16 bytes via [StructLayout(Size = 16)]; the trailing 8 bytes
+        // are intentional padding for backend-specific bit-packing later (see Handles.cs note).
+        await Assert.That(System.Runtime.CompilerServices.Unsafe.SizeOf<BufferHandle>()).IsEqualTo(16);
+        await Assert.That(System.Runtime.CompilerServices.Unsafe.SizeOf<TextureHandle>()).IsEqualTo(16);
+        await Assert.That(System.Runtime.CompilerServices.Unsafe.SizeOf<SamplerHandle>()).IsEqualTo(16);
+        await Assert.That(System.Runtime.CompilerServices.Unsafe.SizeOf<PipelineHandle>()).IsEqualTo(16);
+        await Assert.That(System.Runtime.CompilerServices.Unsafe.SizeOf<ShaderHandle>()).IsEqualTo(16);
+        await Assert.That(System.Runtime.CompilerServices.Unsafe.SizeOf<RenderViewHandle>()).IsEqualTo(16);
+    }
 }

--- a/src/Paradise.Rendering.Test/Paradise.Rendering.Test.csproj
+++ b/src/Paradise.Rendering.Test/Paradise.Rendering.Test.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Paradise.Rendering.Test</AssemblyName>
+    <RootNamespace>Paradise.Rendering.Test</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paradise.Rendering\Paradise.Rendering.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="fixtures\reflection.sample.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/Paradise.Rendering.Test/Paradise.Rendering.Test.csproj
+++ b/src/Paradise.Rendering.Test/Paradise.Rendering.Test.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="fixtures\reflection.sample.json">
+    <None Update="fixtures/reflection.sample.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/Paradise.Rendering.Test/RenderPassDescTests.cs
+++ b/src/Paradise.Rendering.Test/RenderPassDescTests.cs
@@ -135,6 +135,29 @@ public class RenderPassDescTests
     }
 
     [Test]
+    public async Task raw_colors_write_outside_count_is_invisible_to_count_aware_paths()
+    {
+        // Documented contract (RenderPassDesc.Colors XML doc): direct writes to slots
+        // [ColorAttachmentCount, MaxColorAttachments) are silently invisible to the indexer
+        // and span. Pin the invariant so a future refactor that "helpfully" widens the count
+        // or rebases the span breaks here instead of producing a debugging mystery.
+        var pass = new RenderPassDesc(colorAttachmentCount: 2);
+        var hidden = new ColorAttachmentDesc(new RenderViewHandle(77, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.Red);
+        pass.Colors.Slot7 = hidden;
+
+        await Assert.That(pass.ColorAttachmentCount).IsEqualTo(2);
+        await Assert.That(GetSpanLength(ref pass)).IsEqualTo(2);
+        await Assert.That(() =>
+        {
+            var p = new RenderPassDesc(colorAttachmentCount: 2);
+            p.Colors.Slot7 = new ColorAttachmentDesc(new RenderViewHandle(77, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.Red);
+            _ = p[7];
+        }).Throws<ArgumentOutOfRangeException>();
+
+        static int GetSpanLength(ref RenderPassDesc pass) => pass.ColorAttachments.Length;
+    }
+
+    [Test]
     public async Task depth_attachment_is_optional()
     {
         var pass = new RenderPassDesc(colorAttachmentCount: 0);

--- a/src/Paradise.Rendering.Test/RenderPassDescTests.cs
+++ b/src/Paradise.Rendering.Test/RenderPassDescTests.cs
@@ -10,32 +10,31 @@ public class RenderPassDescTests
         var view1 = new RenderViewHandle(11, 1);
         var view2 = new RenderViewHandle(12, 1);
 
-        pass.Colors[0] = new ColorAttachmentDesc(view0, LoadOp.Clear, StoreOp.Store, ColorRgba.Red);
-        pass.Colors[1] = new ColorAttachmentDesc(view1, LoadOp.Load, StoreOp.Store, ColorRgba.Green);
-        pass.Colors[2] = new ColorAttachmentDesc(view2, LoadOp.Clear, StoreOp.Discard, ColorRgba.Blue);
+        pass[0] = new ColorAttachmentDesc(view0, LoadOp.Clear, StoreOp.Store, ColorRgba.Red);
+        pass[1] = new ColorAttachmentDesc(view1, LoadOp.Load, StoreOp.Store, ColorRgba.Green);
+        pass[2] = new ColorAttachmentDesc(view2, LoadOp.Clear, StoreOp.Discard, ColorRgba.Blue);
 
-        await Assert.That(pass.Colors[0].View).IsEqualTo(view0);
-        await Assert.That(pass.Colors[1].View).IsEqualTo(view1);
-        await Assert.That(pass.Colors[2].View).IsEqualTo(view2);
-        await Assert.That(pass.Colors[0].ClearValue).IsEqualTo(ColorRgba.Red);
-        await Assert.That(pass.Colors[2].Store).IsEqualTo(StoreOp.Discard);
+        await Assert.That(pass[0].View).IsEqualTo(view0);
+        await Assert.That(pass[1].View).IsEqualTo(view1);
+        await Assert.That(pass[2].View).IsEqualTo(view2);
+        await Assert.That(pass[0].ClearValue).IsEqualTo(ColorRgba.Red);
+        await Assert.That(pass[2].Store).IsEqualTo(StoreOp.Discard);
     }
 
     [Test]
     public async Task color_attachment_span_reflects_count()
     {
         var pass = new RenderPassDesc(colorAttachmentCount: 2);
-        pass.Colors[0] = new ColorAttachmentDesc(new RenderViewHandle(1, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.White);
-        pass.Colors[1] = new ColorAttachmentDesc(new RenderViewHandle(2, 1), LoadOp.Load, StoreOp.Store, ColorRgba.Black);
+        pass[0] = new ColorAttachmentDesc(new RenderViewHandle(1, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.White);
+        pass[1] = new ColorAttachmentDesc(new RenderViewHandle(2, 1), LoadOp.Load, StoreOp.Store, ColorRgba.Black);
 
-        // Capture span length before any further use, then exit unsafe span context before await.
         var (length, view0, view1) = ReadSpan(ref pass);
         await Assert.That(length).IsEqualTo(2);
         await Assert.That(view0).IsEqualTo(new RenderViewHandle(1, 1));
         await Assert.That(view1).IsEqualTo(new RenderViewHandle(2, 1));
 
         WriteSpanSlot0(ref pass, new ColorAttachmentDesc(new RenderViewHandle(99, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.Red));
-        await Assert.That(pass.Colors[0].View).IsEqualTo(new RenderViewHandle(99, 1));
+        await Assert.That(pass[0].View).IsEqualTo(new RenderViewHandle(99, 1));
 
         static (int length, RenderViewHandle view0, RenderViewHandle view1) ReadSpan(ref RenderPassDesc pass)
         {
@@ -57,12 +56,31 @@ public class RenderPassDescTests
     }
 
     [Test]
-    public async Task color_attachment_indexer_out_of_range_throws()
+    public async Task indexer_above_count_throws_even_within_max_storage()
+    {
+        // Regression: prior to OpenCara F1, writes at indices in [count, MaxColorAttachments)
+        // succeeded silently and were invisible to the count-aware span. The count-aware indexer
+        // now refuses such accesses.
+        await Assert.That(() =>
+        {
+            var pass = new RenderPassDesc(colorAttachmentCount: 2);
+            _ = pass[5];
+        }).Throws<ArgumentOutOfRangeException>();
+
+        await Assert.That(() =>
+        {
+            var pass = new RenderPassDesc(colorAttachmentCount: 2);
+            pass[5] = new ColorAttachmentDesc(new RenderViewHandle(99, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.Red);
+        }).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task indexer_at_or_above_max_throws()
     {
         await Assert.That(() =>
         {
-            var pass = new RenderPassDesc(colorAttachmentCount: 1);
-            _ = pass.Colors[RenderPassDesc.MaxColorAttachments];
+            var pass = new RenderPassDesc(colorAttachmentCount: RenderPassDesc.MaxColorAttachments);
+            _ = pass[RenderPassDesc.MaxColorAttachments];
         }).Throws<ArgumentOutOfRangeException>();
     }
 

--- a/src/Paradise.Rendering.Test/RenderPassDescTests.cs
+++ b/src/Paradise.Rendering.Test/RenderPassDescTests.cs
@@ -85,6 +85,56 @@ public class RenderPassDescTests
     }
 
     [Test]
+    public async Task color_attachment_count_setter_rejects_negative()
+    {
+        // Regression for OpenCara F1-prime: the prior public mutable field allowed
+        // pass.ColorAttachmentCount = -1, and (uint)(-1) == 0xFFFFFFFF made the count-aware
+        // indexer's `(uint)index >= (uint)Count` check vacuous. The validated setter closes that.
+        await Assert.That(() =>
+        {
+            var pass = new RenderPassDesc(colorAttachmentCount: 2);
+            pass.ColorAttachmentCount = -1;
+        }).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task color_attachment_count_setter_rejects_above_max()
+    {
+        // Regression for OpenCara F1-prime: the prior public mutable field allowed
+        // pass.ColorAttachmentCount = 100, after which MemoryMarshal.CreateSpan returned a
+        // 100-element span over the 8-slot inline buffer. The validated setter closes that.
+        await Assert.That(() =>
+        {
+            var pass = new RenderPassDesc(colorAttachmentCount: 2);
+            pass.ColorAttachmentCount = RenderPassDesc.MaxColorAttachments + 1;
+        }).Throws<ArgumentOutOfRangeException>();
+
+        await Assert.That(() =>
+        {
+            var pass = new RenderPassDesc(colorAttachmentCount: 2);
+            pass.ColorAttachmentCount = 100;
+        }).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task color_attachment_count_setter_grows_and_shrinks_within_bounds()
+    {
+        var pass = new RenderPassDesc(colorAttachmentCount: 2);
+        pass[0] = new ColorAttachmentDesc(new RenderViewHandle(1, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.White);
+        pass[1] = new ColorAttachmentDesc(new RenderViewHandle(2, 1), LoadOp.Load, StoreOp.Store, ColorRgba.Black);
+
+        pass.ColorAttachmentCount = RenderPassDesc.MaxColorAttachments;
+        await Assert.That(pass.ColorAttachmentCount).IsEqualTo(RenderPassDesc.MaxColorAttachments);
+        await Assert.That(GetSpanLength(ref pass)).IsEqualTo(RenderPassDesc.MaxColorAttachments);
+
+        pass.ColorAttachmentCount = 0;
+        await Assert.That(pass.ColorAttachmentCount).IsEqualTo(0);
+        await Assert.That(GetSpanLength(ref pass)).IsEqualTo(0);
+
+        static int GetSpanLength(ref RenderPassDesc pass) => pass.ColorAttachments.Length;
+    }
+
+    [Test]
     public async Task depth_attachment_is_optional()
     {
         var pass = new RenderPassDesc(colorAttachmentCount: 0);

--- a/src/Paradise.Rendering.Test/RenderPassDescTests.cs
+++ b/src/Paradise.Rendering.Test/RenderPassDescTests.cs
@@ -1,0 +1,80 @@
+namespace Paradise.Rendering.Test;
+
+public class RenderPassDescTests
+{
+    [Test]
+    public async Task inline_color_attachments_round_trip_through_indexer()
+    {
+        var pass = new RenderPassDesc(colorAttachmentCount: 3);
+        var view0 = new RenderViewHandle(10, 1);
+        var view1 = new RenderViewHandle(11, 1);
+        var view2 = new RenderViewHandle(12, 1);
+
+        pass.Colors[0] = new ColorAttachmentDesc(view0, LoadOp.Clear, StoreOp.Store, ColorRgba.Red);
+        pass.Colors[1] = new ColorAttachmentDesc(view1, LoadOp.Load, StoreOp.Store, ColorRgba.Green);
+        pass.Colors[2] = new ColorAttachmentDesc(view2, LoadOp.Clear, StoreOp.Discard, ColorRgba.Blue);
+
+        await Assert.That(pass.Colors[0].View).IsEqualTo(view0);
+        await Assert.That(pass.Colors[1].View).IsEqualTo(view1);
+        await Assert.That(pass.Colors[2].View).IsEqualTo(view2);
+        await Assert.That(pass.Colors[0].ClearValue).IsEqualTo(ColorRgba.Red);
+        await Assert.That(pass.Colors[2].Store).IsEqualTo(StoreOp.Discard);
+    }
+
+    [Test]
+    public async Task color_attachment_span_reflects_count()
+    {
+        var pass = new RenderPassDesc(colorAttachmentCount: 2);
+        pass.Colors[0] = new ColorAttachmentDesc(new RenderViewHandle(1, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.White);
+        pass.Colors[1] = new ColorAttachmentDesc(new RenderViewHandle(2, 1), LoadOp.Load, StoreOp.Store, ColorRgba.Black);
+
+        // Capture span length before any further use, then exit unsafe span context before await.
+        var (length, view0, view1) = ReadSpan(ref pass);
+        await Assert.That(length).IsEqualTo(2);
+        await Assert.That(view0).IsEqualTo(new RenderViewHandle(1, 1));
+        await Assert.That(view1).IsEqualTo(new RenderViewHandle(2, 1));
+
+        WriteSpanSlot0(ref pass, new ColorAttachmentDesc(new RenderViewHandle(99, 1), LoadOp.Clear, StoreOp.Store, ColorRgba.Red));
+        await Assert.That(pass.Colors[0].View).IsEqualTo(new RenderViewHandle(99, 1));
+
+        static (int length, RenderViewHandle view0, RenderViewHandle view1) ReadSpan(ref RenderPassDesc pass)
+        {
+            var span = pass.ColorAttachments;
+            return (span.Length, span[0].View, span[1].View);
+        }
+
+        static void WriteSpanSlot0(ref RenderPassDesc pass, ColorAttachmentDesc value)
+        {
+            var span = pass.ColorAttachments;
+            span[0] = value;
+        }
+    }
+
+    [Test]
+    public async Task color_attachment_count_above_max_throws()
+    {
+        await Assert.That(() => new RenderPassDesc(colorAttachmentCount: RenderPassDesc.MaxColorAttachments + 1)).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task color_attachment_indexer_out_of_range_throws()
+    {
+        await Assert.That(() =>
+        {
+            var pass = new RenderPassDesc(colorAttachmentCount: 1);
+            _ = pass.Colors[RenderPassDesc.MaxColorAttachments];
+        }).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task depth_attachment_is_optional()
+    {
+        var pass = new RenderPassDesc(colorAttachmentCount: 0);
+        await Assert.That(pass.Depth.HasValue).IsFalse();
+
+        var depth = new DepthAttachmentDesc(new TextureHandle(5, 1), LoadOp.Clear, StoreOp.Store, 1.0f);
+        var pass2 = new RenderPassDesc(colorAttachmentCount: 0, depth: depth);
+        await Assert.That(pass2.Depth.HasValue).IsTrue();
+        await Assert.That(pass2.Depth!.Value.ClearDepth).IsEqualTo(1.0f);
+    }
+}

--- a/src/Paradise.Rendering.Test/ShaderReflectionJsonTests.cs
+++ b/src/Paradise.Rendering.Test/ShaderReflectionJsonTests.cs
@@ -1,0 +1,130 @@
+using System.IO;
+using System.Text.Json;
+
+namespace Paradise.Rendering.Test;
+
+public class ShaderReflectionJsonTests
+{
+    private static string FixturePath() =>
+        Path.Combine(AppContext.BaseDirectory, "fixtures", "reflection.sample.json");
+
+    private static ShaderProgramDesc DeserializeFixture()
+    {
+        var json = File.ReadAllText(FixturePath());
+        var program = JsonSerializer.Deserialize(json, ShaderReflectionJsonContext.Default.ShaderProgramDesc);
+        if (program is null) throw new InvalidOperationException("Fixture failed to deserialize.");
+        return program;
+    }
+
+    [Test]
+    public async Task fixture_deserializes_into_shader_program_desc()
+    {
+        var program = DeserializeFixture();
+
+        await Assert.That(program.Modules.Length).IsEqualTo(2);
+        await Assert.That(program.Modules[0].EntryPoint).IsEqualTo("vs_main");
+        await Assert.That(program.Modules[0].Stage).IsEqualTo(ShaderStage.Vertex);
+        await Assert.That(program.Modules[1].EntryPoint).IsEqualTo("fs_main");
+        await Assert.That(program.Modules[1].Stage).IsEqualTo(ShaderStage.Fragment);
+    }
+
+    [Test]
+    public async Task fixture_pipeline_layout_has_one_group_with_uniform_entry()
+    {
+        var program = DeserializeFixture();
+        await Assert.That(program.Layout.Groups.Length).IsEqualTo(1);
+        var group = program.Layout.Groups[0];
+        await Assert.That(group.GroupIndex).IsEqualTo(0u);
+        await Assert.That(group.Entries.Length).IsEqualTo(1);
+
+        var entry = group.Entries[0];
+        await Assert.That(entry.Binding).IsEqualTo(0u);
+        await Assert.That(entry.Type).IsEqualTo(BindingResourceType.UniformBuffer);
+        await Assert.That(entry.MinBufferSize).IsEqualTo(64ul);
+        await Assert.That((entry.Visibility & ShaderStage.Vertex) == ShaderStage.Vertex).IsTrue();
+        await Assert.That((entry.Visibility & ShaderStage.Fragment) == ShaderStage.Fragment).IsTrue();
+    }
+
+    [Test]
+    public async Task fixture_push_constants_round_trip()
+    {
+        var program = DeserializeFixture();
+        await Assert.That(program.Layout.PushConstants.Length).IsEqualTo(1);
+        var pc = program.Layout.PushConstants[0];
+        await Assert.That(pc.Visibility).IsEqualTo(ShaderStage.Vertex);
+        await Assert.That(pc.Offset).IsEqualTo(0u);
+        await Assert.That(pc.Size).IsEqualTo(16u);
+    }
+
+    [Test]
+    public async Task fixture_vertex_buffer_layout_matches_expected_attributes()
+    {
+        var program = DeserializeFixture();
+        await Assert.That(program.VertexBuffers.Length).IsEqualTo(1);
+        var vb = program.VertexBuffers[0];
+        await Assert.That(vb.Stride).IsEqualTo(20ul);
+        await Assert.That(vb.StepMode).IsEqualTo(VertexStepMode.Vertex);
+        await Assert.That(vb.Attributes.Length).IsEqualTo(2);
+
+        await Assert.That(vb.Attributes[0].ShaderLocation).IsEqualTo(0u);
+        await Assert.That(vb.Attributes[0].Format).IsEqualTo(VertexFormat.Float32x2);
+        await Assert.That(vb.Attributes[0].Offset).IsEqualTo(0ul);
+
+        await Assert.That(vb.Attributes[1].ShaderLocation).IsEqualTo(1u);
+        await Assert.That(vb.Attributes[1].Format).IsEqualTo(VertexFormat.Float32x3);
+        await Assert.That(vb.Attributes[1].Offset).IsEqualTo(8ul);
+    }
+
+    [Test]
+    public async Task serialize_then_deserialize_preserves_structural_equality()
+    {
+        var original = DeserializeFixture();
+        var json = JsonSerializer.Serialize(original, ShaderReflectionJsonContext.Default.ShaderProgramDesc);
+        var roundTripped = JsonSerializer.Deserialize(json, ShaderReflectionJsonContext.Default.ShaderProgramDesc);
+        if (roundTripped is null) throw new InvalidOperationException("Round-trip deserialization returned null.");
+
+        await AssertProgramsEqualAsync(original, roundTripped).ConfigureAwait(false);
+    }
+
+    private static async Task AssertProgramsEqualAsync(ShaderProgramDesc a, ShaderProgramDesc b)
+    {
+        await Assert.That(a.Modules.Length).IsEqualTo(b.Modules.Length);
+        for (var i = 0; i < a.Modules.Length; i++)
+        {
+            await Assert.That(a.Modules[i]).IsEqualTo(b.Modules[i]);
+        }
+
+        await Assert.That(a.Layout.Groups.Length).IsEqualTo(b.Layout.Groups.Length);
+        for (var i = 0; i < a.Layout.Groups.Length; i++)
+        {
+            var ag = a.Layout.Groups[i];
+            var bg = b.Layout.Groups[i];
+            await Assert.That(ag.GroupIndex).IsEqualTo(bg.GroupIndex);
+            await Assert.That(ag.Entries.Length).IsEqualTo(bg.Entries.Length);
+            for (var j = 0; j < ag.Entries.Length; j++)
+            {
+                await Assert.That(ag.Entries[j]).IsEqualTo(bg.Entries[j]);
+            }
+        }
+
+        await Assert.That(a.Layout.PushConstants.Length).IsEqualTo(b.Layout.PushConstants.Length);
+        for (var i = 0; i < a.Layout.PushConstants.Length; i++)
+        {
+            await Assert.That(a.Layout.PushConstants[i]).IsEqualTo(b.Layout.PushConstants[i]);
+        }
+
+        await Assert.That(a.VertexBuffers.Length).IsEqualTo(b.VertexBuffers.Length);
+        for (var i = 0; i < a.VertexBuffers.Length; i++)
+        {
+            var av = a.VertexBuffers[i];
+            var bv = b.VertexBuffers[i];
+            await Assert.That(av.Stride).IsEqualTo(bv.Stride);
+            await Assert.That(av.StepMode).IsEqualTo(bv.StepMode);
+            await Assert.That(av.Attributes.Length).IsEqualTo(bv.Attributes.Length);
+            for (var j = 0; j < av.Attributes.Length; j++)
+            {
+                await Assert.That(av.Attributes[j]).IsEqualTo(bv.Attributes[j]);
+            }
+        }
+    }
+}

--- a/src/Paradise.Rendering.Test/ShaderReflectionJsonTests.cs
+++ b/src/Paradise.Rendering.Test/ShaderReflectionJsonTests.cs
@@ -41,8 +41,10 @@ public class ShaderReflectionJsonTests
         await Assert.That(entry.Binding).IsEqualTo(0u);
         await Assert.That(entry.Type).IsEqualTo(BindingResourceType.UniformBuffer);
         await Assert.That(entry.MinBufferSize).IsEqualTo(64ul);
-        await Assert.That((entry.Visibility & ShaderStage.Vertex) == ShaderStage.Vertex).IsTrue();
-        await Assert.That((entry.Visibility & ShaderStage.Fragment) == ShaderStage.Fragment).IsTrue();
+        // Direct flag-equality assertion (per OpenCara minor risk on STJ flags round-trip):
+        // makes the comma-separated "Vertex, Fragment" -> ShaderStage.Vertex|Fragment path
+        // an explicit invariant rather than relying on bitwise spot-checks.
+        await Assert.That(entry.Visibility).IsEqualTo(ShaderStage.Vertex | ShaderStage.Fragment);
     }
 
     [Test]

--- a/src/Paradise.Rendering.Test/SurfaceDescriptorTests.cs
+++ b/src/Paradise.Rendering.Test/SurfaceDescriptorTests.cs
@@ -1,0 +1,47 @@
+namespace Paradise.Rendering.Test;
+
+public class SurfaceDescriptorTests
+{
+    [Test]
+    public async Task all_platform_variants_round_trip_their_fields()
+    {
+        foreach (var platform in Enum.GetValues<SurfacePlatform>())
+        {
+            var desc = new SurfaceDescriptor(
+                platform,
+                displayHandle: new IntPtr(0xCAFE),
+                windowHandle: new IntPtr(0xBEEF),
+                width: 1920,
+                height: 1080);
+
+            await Assert.That(desc.Platform).IsEqualTo(platform);
+            await Assert.That(desc.DisplayHandle).IsEqualTo(new IntPtr(0xCAFE));
+            await Assert.That(desc.WindowHandle).IsEqualTo(new IntPtr(0xBEEF));
+            await Assert.That(desc.Width).IsEqualTo(1920u);
+            await Assert.That(desc.Height).IsEqualTo(1080u);
+        }
+    }
+
+    [Test]
+    public async Task headless_factory_zero_handles_and_headless_platform()
+    {
+        var desc = SurfaceDescriptor.Headless(800, 600);
+        await Assert.That(desc.Platform).IsEqualTo(SurfacePlatform.Headless);
+        await Assert.That(desc.DisplayHandle).IsEqualTo(IntPtr.Zero);
+        await Assert.That(desc.WindowHandle).IsEqualTo(IntPtr.Zero);
+        await Assert.That(desc.Width).IsEqualTo(800u);
+        await Assert.That(desc.Height).IsEqualTo(600u);
+    }
+
+    [Test]
+    public async Task equality_matches_field_by_field()
+    {
+        var a = new SurfaceDescriptor(SurfacePlatform.Wayland, new IntPtr(1), new IntPtr(2), 100, 100);
+        var b = new SurfaceDescriptor(SurfacePlatform.Wayland, new IntPtr(1), new IntPtr(2), 100, 100);
+        var c = new SurfaceDescriptor(SurfacePlatform.Xlib, new IntPtr(1), new IntPtr(2), 100, 100);
+        await Assert.That(a).IsEqualTo(b);
+        await Assert.That(a == b).IsTrue();
+        await Assert.That(a == c).IsFalse();
+        await Assert.That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
+    }
+}

--- a/src/Paradise.Rendering.Test/SurfaceDescriptorTests.cs
+++ b/src/Paradise.Rendering.Test/SurfaceDescriptorTests.cs
@@ -9,10 +9,10 @@ public class SurfaceDescriptorTests
         {
             var desc = new SurfaceDescriptor(
                 platform,
-                displayHandle: new IntPtr(0xCAFE),
-                windowHandle: new IntPtr(0xBEEF),
-                width: 1920,
-                height: 1080);
+                DisplayHandle: new IntPtr(0xCAFE),
+                WindowHandle: new IntPtr(0xBEEF),
+                Width: 1920,
+                Height: 1080);
 
             await Assert.That(desc.Platform).IsEqualTo(platform);
             await Assert.That(desc.DisplayHandle).IsEqualTo(new IntPtr(0xCAFE));

--- a/src/Paradise.Rendering.Test/Usings.cs
+++ b/src/Paradise.Rendering.Test/Usings.cs
@@ -1,0 +1,4 @@
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using Paradise.Rendering;

--- a/src/Paradise.Rendering.Test/fixtures/reflection.sample.json
+++ b/src/Paradise.Rendering.Test/fixtures/reflection.sample.json
@@ -1,0 +1,54 @@
+{
+  "modules": [
+    {
+      "wgsl": "@vertex fn vs_main(@location(0) pos: vec2<f32>, @location(1) color: vec3<f32>) -> @builtin(position) vec4<f32> { return vec4<f32>(pos, 0.0, 1.0); }",
+      "entry_point": "vs_main",
+      "stage": "Vertex"
+    },
+    {
+      "wgsl": "@fragment fn fs_main(@location(0) color: vec3<f32>) -> @location(0) vec4<f32> { return vec4<f32>(color, 1.0); }",
+      "entry_point": "fs_main",
+      "stage": "Fragment"
+    }
+  ],
+  "layout": {
+    "groups": [
+      {
+        "group_index": 0,
+        "entries": [
+          {
+            "binding": 0,
+            "visibility": "Vertex, Fragment",
+            "type": "UniformBuffer",
+            "min_buffer_size": 64
+          }
+        ]
+      }
+    ],
+    "push_constants": [
+      {
+        "visibility": "Vertex",
+        "offset": 0,
+        "size": 16
+      }
+    ]
+  },
+  "vertex_buffers": [
+    {
+      "stride": 20,
+      "step_mode": "Vertex",
+      "attributes": [
+        {
+          "shader_location": 0,
+          "format": "Float32x2",
+          "offset": 0
+        },
+        {
+          "shader_location": 1,
+          "format": "Float32x3",
+          "offset": 8
+        }
+      ]
+    }
+  ]
+}

--- a/src/Paradise.Rendering/ColorRgba.cs
+++ b/src/Paradise.Rendering/ColorRgba.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Paradise.Rendering;
+
+/// <summary>Linear-space RGBA color with float components in [0,1]. Used for clear values and uniform inputs.</summary>
+public readonly struct ColorRgba : IEquatable<ColorRgba>
+{
+    public readonly float R;
+    public readonly float G;
+    public readonly float B;
+    public readonly float A;
+
+    public ColorRgba(float r, float g, float b, float a)
+    {
+        R = r;
+        G = g;
+        B = b;
+        A = a;
+    }
+
+    public static readonly ColorRgba Black = new(0f, 0f, 0f, 1f);
+    public static readonly ColorRgba White = new(1f, 1f, 1f, 1f);
+    public static readonly ColorRgba Red = new(1f, 0f, 0f, 1f);
+    public static readonly ColorRgba Green = new(0f, 1f, 0f, 1f);
+    public static readonly ColorRgba Blue = new(0f, 0f, 1f, 1f);
+    public static readonly ColorRgba Transparent = new(0f, 0f, 0f, 0f);
+    public static readonly ColorRgba CornflowerBlue = new(0.392f, 0.584f, 0.929f, 1f);
+
+    public bool Equals(ColorRgba other) => R == other.R && G == other.G && B == other.B && A == other.A;
+    public override bool Equals(object? obj) => obj is ColorRgba other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(R, G, B, A);
+    public static bool operator ==(ColorRgba left, ColorRgba right) => left.Equals(right);
+    public static bool operator !=(ColorRgba left, ColorRgba right) => !left.Equals(right);
+}

--- a/src/Paradise.Rendering/ColorRgba.cs
+++ b/src/Paradise.Rendering/ColorRgba.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Paradise.Rendering;
 
 /// <summary>RGBA color with float components in [0,1]. Used for clear values and uniform inputs.
@@ -8,21 +6,8 @@ namespace Paradise.Rendering;
 /// an <c>Rgba8Unorm</c> attachment treats it as linear). The named constants below use the
 /// canonical sRGB shorthand familiar from XNA / WPF — convert to linear at the call site if your
 /// pipeline requires it.</summary>
-public readonly struct ColorRgba : IEquatable<ColorRgba>
+public readonly record struct ColorRgba(float R, float G, float B, float A)
 {
-    public readonly float R;
-    public readonly float G;
-    public readonly float B;
-    public readonly float A;
-
-    public ColorRgba(float r, float g, float b, float a)
-    {
-        R = r;
-        G = g;
-        B = b;
-        A = a;
-    }
-
     public static readonly ColorRgba Black = new(0f, 0f, 0f, 1f);
     public static readonly ColorRgba White = new(1f, 1f, 1f, 1f);
     public static readonly ColorRgba Red = new(1f, 0f, 0f, 1f);
@@ -30,10 +15,4 @@ public readonly struct ColorRgba : IEquatable<ColorRgba>
     public static readonly ColorRgba Blue = new(0f, 0f, 1f, 1f);
     public static readonly ColorRgba Transparent = new(0f, 0f, 0f, 0f);
     public static readonly ColorRgba CornflowerBlue = new(0.392f, 0.584f, 0.929f, 1f);
-
-    public bool Equals(ColorRgba other) => R == other.R && G == other.G && B == other.B && A == other.A;
-    public override bool Equals(object? obj) => obj is ColorRgba other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(R, G, B, A);
-    public static bool operator ==(ColorRgba left, ColorRgba right) => left.Equals(right);
-    public static bool operator !=(ColorRgba left, ColorRgba right) => !left.Equals(right);
 }

--- a/src/Paradise.Rendering/ColorRgba.cs
+++ b/src/Paradise.Rendering/ColorRgba.cs
@@ -2,7 +2,12 @@ using System;
 
 namespace Paradise.Rendering;
 
-/// <summary>Linear-space RGBA color with float components in [0,1]. Used for clear values and uniform inputs.</summary>
+/// <summary>RGBA color with float components in [0,1]. Used for clear values and uniform inputs.
+/// Color space is consumer-defined: backends interpret the components according to the bound
+/// render attachment's format (e.g. an <c>Rgba8UnormSrgb</c> attachment treats the value as sRGB,
+/// an <c>Rgba8Unorm</c> attachment treats it as linear). The named constants below use the
+/// canonical sRGB shorthand familiar from XNA / WPF — convert to linear at the call site if your
+/// pipeline requires it.</summary>
 public readonly struct ColorRgba : IEquatable<ColorRgba>
 {
     public readonly float R;

--- a/src/Paradise.Rendering/Commands.cs
+++ b/src/Paradise.Rendering/Commands.cs
@@ -1,52 +1,22 @@
 namespace Paradise.Rendering;
 
 /// <summary>Non-indexed draw call parameters.</summary>
-public readonly struct DrawCommand
-{
-    public readonly uint VertexCount;
-    public readonly uint InstanceCount;
-    public readonly uint FirstVertex;
-    public readonly uint FirstInstance;
-
-    public DrawCommand(uint vertexCount, uint instanceCount, uint firstVertex, uint firstInstance)
-    {
-        VertexCount = vertexCount;
-        InstanceCount = instanceCount;
-        FirstVertex = firstVertex;
-        FirstInstance = firstInstance;
-    }
-}
+public readonly record struct DrawCommand(
+    uint VertexCount,
+    uint InstanceCount,
+    uint FirstVertex,
+    uint FirstInstance);
 
 /// <summary>Indexed draw call parameters.</summary>
-public readonly struct DrawIndexedCommand
-{
-    public readonly uint IndexCount;
-    public readonly uint InstanceCount;
-    public readonly uint FirstIndex;
-    public readonly int BaseVertex;
-    public readonly uint FirstInstance;
-
-    public DrawIndexedCommand(uint indexCount, uint instanceCount, uint firstIndex, int baseVertex, uint firstInstance)
-    {
-        IndexCount = indexCount;
-        InstanceCount = instanceCount;
-        FirstIndex = firstIndex;
-        BaseVertex = baseVertex;
-        FirstInstance = firstInstance;
-    }
-}
+public readonly record struct DrawIndexedCommand(
+    uint IndexCount,
+    uint InstanceCount,
+    uint FirstIndex,
+    int BaseVertex,
+    uint FirstInstance);
 
 /// <summary>Compute dispatch parameters.</summary>
-public readonly struct DispatchCommand
-{
-    public readonly uint WorkgroupCountX;
-    public readonly uint WorkgroupCountY;
-    public readonly uint WorkgroupCountZ;
-
-    public DispatchCommand(uint workgroupCountX, uint workgroupCountY, uint workgroupCountZ)
-    {
-        WorkgroupCountX = workgroupCountX;
-        WorkgroupCountY = workgroupCountY;
-        WorkgroupCountZ = workgroupCountZ;
-    }
-}
+public readonly record struct DispatchCommand(
+    uint WorkgroupCountX,
+    uint WorkgroupCountY,
+    uint WorkgroupCountZ);

--- a/src/Paradise.Rendering/Commands.cs
+++ b/src/Paradise.Rendering/Commands.cs
@@ -1,0 +1,52 @@
+namespace Paradise.Rendering;
+
+/// <summary>Non-indexed draw call parameters.</summary>
+public readonly struct DrawCommand
+{
+    public readonly uint VertexCount;
+    public readonly uint InstanceCount;
+    public readonly uint FirstVertex;
+    public readonly uint FirstInstance;
+
+    public DrawCommand(uint vertexCount, uint instanceCount, uint firstVertex, uint firstInstance)
+    {
+        VertexCount = vertexCount;
+        InstanceCount = instanceCount;
+        FirstVertex = firstVertex;
+        FirstInstance = firstInstance;
+    }
+}
+
+/// <summary>Indexed draw call parameters.</summary>
+public readonly struct DrawIndexedCommand
+{
+    public readonly uint IndexCount;
+    public readonly uint InstanceCount;
+    public readonly uint FirstIndex;
+    public readonly int BaseVertex;
+    public readonly uint FirstInstance;
+
+    public DrawIndexedCommand(uint indexCount, uint instanceCount, uint firstIndex, int baseVertex, uint firstInstance)
+    {
+        IndexCount = indexCount;
+        InstanceCount = instanceCount;
+        FirstIndex = firstIndex;
+        BaseVertex = baseVertex;
+        FirstInstance = firstInstance;
+    }
+}
+
+/// <summary>Compute dispatch parameters.</summary>
+public readonly struct DispatchCommand
+{
+    public readonly uint WorkgroupCountX;
+    public readonly uint WorkgroupCountY;
+    public readonly uint WorkgroupCountZ;
+
+    public DispatchCommand(uint workgroupCountX, uint workgroupCountY, uint workgroupCountZ)
+    {
+        WorkgroupCountX = workgroupCountX;
+        WorkgroupCountY = workgroupCountY;
+        WorkgroupCountZ = workgroupCountZ;
+    }
+}

--- a/src/Paradise.Rendering/Descriptors/AttachmentDescs.cs
+++ b/src/Paradise.Rendering/Descriptors/AttachmentDescs.cs
@@ -1,35 +1,24 @@
+using System.Runtime.InteropServices;
+
 namespace Paradise.Rendering;
 
 /// <summary>Color attachment binding for a single render-pass color slot.</summary>
-public readonly struct ColorAttachmentDesc
-{
-    public readonly RenderViewHandle View;
-    public readonly LoadOp Load;
-    public readonly StoreOp Store;
-    public readonly ColorRgba ClearValue;
-
-    public ColorAttachmentDesc(RenderViewHandle view, LoadOp load, StoreOp store, ColorRgba clearValue)
-    {
-        View = view;
-        Load = load;
-        Store = store;
-        ClearValue = clearValue;
-    }
-}
+/// <remarks>Sequential layout is required: <see cref="ColorAttachmentBuffer"/> stores instances
+/// inline and <see cref="RenderPassDesc"/> walks them via <see cref="System.Runtime.CompilerServices.Unsafe.Add{T}(ref T, int)"/>.</remarks>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct ColorAttachmentDesc(
+    RenderViewHandle View,
+    LoadOp Load,
+    StoreOp Store,
+    ColorRgba ClearValue);
 
 /// <summary>Depth attachment binding for a render pass.</summary>
-public readonly struct DepthAttachmentDesc
-{
-    public readonly TextureHandle DepthTexture;
-    public readonly LoadOp DepthLoad;
-    public readonly StoreOp DepthStore;
-    public readonly float ClearDepth;
-
-    public DepthAttachmentDesc(TextureHandle depthTexture, LoadOp depthLoad, StoreOp depthStore, float clearDepth)
-    {
-        DepthTexture = depthTexture;
-        DepthLoad = depthLoad;
-        DepthStore = depthStore;
-        ClearDepth = clearDepth;
-    }
-}
+// TODO(post-M0a): when the contract grows to express stencil load/store/clear, fold them in here
+//                 (or split into DepthStencilAttachmentDesc) so combined formats like
+//                 TextureFormat.Depth24PlusStencil8 round-trip without losing stencil intent.
+//                 Tracked alongside PipelineDesc placeholder expansion in #42 / #45.
+public readonly record struct DepthAttachmentDesc(
+    TextureHandle DepthTexture,
+    LoadOp DepthLoad,
+    StoreOp DepthStore,
+    float ClearDepth);

--- a/src/Paradise.Rendering/Descriptors/AttachmentDescs.cs
+++ b/src/Paradise.Rendering/Descriptors/AttachmentDescs.cs
@@ -1,0 +1,35 @@
+namespace Paradise.Rendering;
+
+/// <summary>Color attachment binding for a single render-pass color slot.</summary>
+public readonly struct ColorAttachmentDesc
+{
+    public readonly RenderViewHandle View;
+    public readonly LoadOp Load;
+    public readonly StoreOp Store;
+    public readonly ColorRgba ClearValue;
+
+    public ColorAttachmentDesc(RenderViewHandle view, LoadOp load, StoreOp store, ColorRgba clearValue)
+    {
+        View = view;
+        Load = load;
+        Store = store;
+        ClearValue = clearValue;
+    }
+}
+
+/// <summary>Depth attachment binding for a render pass.</summary>
+public readonly struct DepthAttachmentDesc
+{
+    public readonly TextureHandle DepthTexture;
+    public readonly LoadOp DepthLoad;
+    public readonly StoreOp DepthStore;
+    public readonly float ClearDepth;
+
+    public DepthAttachmentDesc(TextureHandle depthTexture, LoadOp depthLoad, StoreOp depthStore, float clearDepth)
+    {
+        DepthTexture = depthTexture;
+        DepthLoad = depthLoad;
+        DepthStore = depthStore;
+        ClearDepth = clearDepth;
+    }
+}

--- a/src/Paradise.Rendering/Descriptors/BufferDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/BufferDesc.cs
@@ -1,18 +1,8 @@
 namespace Paradise.Rendering;
 
 /// <summary>Creation parameters for a GPU buffer.</summary>
-public readonly struct BufferDesc
-{
-    public readonly string? Name;
-    public readonly ulong Size;
-    public readonly BufferUsage Usage;
-    public readonly bool MappedAtCreation;
-
-    public BufferDesc(string? name, ulong size, BufferUsage usage, bool mappedAtCreation = false)
-    {
-        Name = name;
-        Size = size;
-        Usage = usage;
-        MappedAtCreation = mappedAtCreation;
-    }
-}
+public readonly record struct BufferDesc(
+    string? Name,
+    ulong Size,
+    BufferUsage Usage,
+    bool MappedAtCreation = false);

--- a/src/Paradise.Rendering/Descriptors/BufferDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/BufferDesc.cs
@@ -1,0 +1,18 @@
+namespace Paradise.Rendering;
+
+/// <summary>Creation parameters for a GPU buffer.</summary>
+public readonly struct BufferDesc
+{
+    public readonly string? Name;
+    public readonly ulong Size;
+    public readonly BufferUsage Usage;
+    public readonly bool MappedAtCreation;
+
+    public BufferDesc(string? name, ulong size, BufferUsage usage, bool mappedAtCreation = false)
+    {
+        Name = name;
+        Size = size;
+        Usage = usage;
+        MappedAtCreation = mappedAtCreation;
+    }
+}

--- a/src/Paradise.Rendering/Descriptors/PipelineDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/PipelineDesc.cs
@@ -1,0 +1,15 @@
+namespace Paradise.Rendering;
+
+/// <summary>Render pipeline descriptor placeholder. Filled in by M1 (#42) — present here so the
+/// contract surface exists for backend stubs and slot tables to reference.</summary>
+// TODO(M1 #42): expand with vertex/fragment shader handles, vertex layouts, color/depth targets,
+//               and reflection-derived PipelineLayoutDesc.
+public readonly struct PipelineDesc
+{
+    public readonly string? Name;
+
+    public PipelineDesc(string? name)
+    {
+        Name = name;
+    }
+}

--- a/src/Paradise.Rendering/Descriptors/PipelineDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/PipelineDesc.cs
@@ -4,12 +4,4 @@ namespace Paradise.Rendering;
 /// contract surface exists for backend stubs and slot tables to reference.</summary>
 // TODO(M1 #42): expand with vertex/fragment shader handles, vertex layouts, color/depth targets,
 //               and reflection-derived PipelineLayoutDesc.
-public readonly struct PipelineDesc
-{
-    public readonly string? Name;
-
-    public PipelineDesc(string? name)
-    {
-        Name = name;
-    }
-}
+public readonly record struct PipelineDesc(string? Name);

--- a/src/Paradise.Rendering/Descriptors/RenderPassDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/RenderPassDesc.cs
@@ -23,15 +23,30 @@ public struct RenderPassDesc
     /// need uniform layout-based marshalling.</summary>
     public ColorAttachmentBuffer Colors;
 
-    public int ColorAttachmentCount;
+    private int _colorAttachmentCount;
+
+    /// <summary>Number of valid entries in <see cref="Colors"/>. Setter validates against
+    /// <c>[0, <see cref="MaxColorAttachments"/>]</c> so the count cannot be raised to enable
+    /// out-of-bounds reads via <see cref="this[int]"/> or <see cref="ColorAttachments"/>.</summary>
+    public int ColorAttachmentCount
+    {
+        readonly get => _colorAttachmentCount;
+        set
+        {
+            if ((uint)value > (uint)MaxColorAttachments)
+                throw new ArgumentOutOfRangeException(nameof(value));
+            _colorAttachmentCount = value;
+        }
+    }
+
     public DepthAttachmentDesc? Depth;
 
     public RenderPassDesc(int colorAttachmentCount, DepthAttachmentDesc? depth = null)
     {
-        if (colorAttachmentCount < 0 || colorAttachmentCount > MaxColorAttachments)
+        if ((uint)colorAttachmentCount > (uint)MaxColorAttachments)
             throw new ArgumentOutOfRangeException(nameof(colorAttachmentCount));
         Colors = default;
-        ColorAttachmentCount = colorAttachmentCount;
+        _colorAttachmentCount = colorAttachmentCount;
         Depth = depth;
     }
 
@@ -43,7 +58,7 @@ public struct RenderPassDesc
         [UnscopedRef]
         get
         {
-            if ((uint)index >= (uint)ColorAttachmentCount)
+            if ((uint)index >= (uint)_colorAttachmentCount)
                 throw new ArgumentOutOfRangeException(nameof(index));
             return ref Unsafe.Add(ref Unsafe.As<ColorAttachmentBuffer, ColorAttachmentDesc>(ref Colors), index);
         }
@@ -52,7 +67,7 @@ public struct RenderPassDesc
     /// <summary>Live span over the color attachment storage, sized by <see cref="ColorAttachmentCount"/>.</summary>
     [UnscopedRef]
     public Span<ColorAttachmentDesc> ColorAttachments =>
-        MemoryMarshal.CreateSpan(ref Unsafe.As<ColorAttachmentBuffer, ColorAttachmentDesc>(ref Colors), ColorAttachmentCount);
+        MemoryMarshal.CreateSpan(ref Unsafe.As<ColorAttachmentBuffer, ColorAttachmentDesc>(ref Colors), _colorAttachmentCount);
 }
 
 /// <summary>Inline storage for up to <see cref="RenderPassDesc.MaxColorAttachments"/> color

--- a/src/Paradise.Rendering/Descriptors/RenderPassDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/RenderPassDesc.cs
@@ -6,14 +6,23 @@ using System.Runtime.InteropServices;
 namespace Paradise.Rendering;
 
 /// <summary>Render pass descriptor with up to <see cref="MaxColorAttachments"/> color attachments
-/// and an optional depth attachment. Color attachments live inline (no heap allocation); use
-/// <see cref="ColorAttachments"/> to read/write a span over the live storage.</summary>
+/// and an optional depth attachment. Color attachments live inline (no heap allocation); use the
+/// <see cref="this[int]"/> indexer or <see cref="ColorAttachments"/> span — both honor
+/// <see cref="ColorAttachmentCount"/>.</summary>
+/// <remarks>This is a mutable struct: it must be passed by <c>ref</c> when mutated. Storing one in a
+/// <see cref="System.Collections.Generic.List{T}"/> field, capturing it as a property getter copy,
+/// or assigning to a local before writing through the indexer will silently lose writes to the copy.</remarks>
 public struct RenderPassDesc
 {
     /// <summary>Maximum number of color attachments per pass. Matches WebGPU's required minimum (8).</summary>
     public const int MaxColorAttachments = 8;
 
+    /// <summary>Raw inline storage for the eight color-attachment slots. Prefer the count-aware
+    /// <see cref="this[int]"/> indexer or <see cref="ColorAttachments"/> span — both bound writes
+    /// to <see cref="ColorAttachmentCount"/>. Direct field access is exposed for backends that
+    /// need uniform layout-based marshalling.</summary>
     public ColorAttachmentBuffer Colors;
+
     public int ColorAttachmentCount;
     public DepthAttachmentDesc? Depth;
 
@@ -26,14 +35,30 @@ public struct RenderPassDesc
         Depth = depth;
     }
 
+    /// <summary>Count-aware color attachment accessor: bounds-checked against
+    /// <see cref="ColorAttachmentCount"/>, not just <see cref="MaxColorAttachments"/>. Writes via
+    /// this indexer are visible to <see cref="ColorAttachments"/>.</summary>
+    public ref ColorAttachmentDesc this[int index]
+    {
+        [UnscopedRef]
+        get
+        {
+            if ((uint)index >= (uint)ColorAttachmentCount)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            return ref Unsafe.Add(ref Unsafe.As<ColorAttachmentBuffer, ColorAttachmentDesc>(ref Colors), index);
+        }
+    }
+
     /// <summary>Live span over the color attachment storage, sized by <see cref="ColorAttachmentCount"/>.</summary>
     [UnscopedRef]
     public Span<ColorAttachmentDesc> ColorAttachments =>
         MemoryMarshal.CreateSpan(ref Unsafe.As<ColorAttachmentBuffer, ColorAttachmentDesc>(ref Colors), ColorAttachmentCount);
 }
 
-/// <summary>Inline storage for up to <see cref="RenderPassDesc.MaxColorAttachments"/> color attachments
-/// inside a <see cref="RenderPassDesc"/>. Access through <see cref="RenderPassDesc.ColorAttachments"/>.</summary>
+/// <summary>Inline storage for up to <see cref="RenderPassDesc.MaxColorAttachments"/> color
+/// attachments inside a <see cref="RenderPassDesc"/>. Sequential layout is required — the
+/// surrounding indexer and span use <see cref="Unsafe.Add{T}(ref T, int)"/> over <see cref="Slot0"/>.</summary>
+[StructLayout(LayoutKind.Sequential)]
 public struct ColorAttachmentBuffer
 {
     public ColorAttachmentDesc Slot0;
@@ -44,16 +69,4 @@ public struct ColorAttachmentBuffer
     public ColorAttachmentDesc Slot5;
     public ColorAttachmentDesc Slot6;
     public ColorAttachmentDesc Slot7;
-
-    /// <summary>Indexer over the inline slots. Bounds-checked against <see cref="RenderPassDesc.MaxColorAttachments"/>.</summary>
-    public ref ColorAttachmentDesc this[int index]
-    {
-        [UnscopedRef]
-        get
-        {
-            if ((uint)index >= (uint)RenderPassDesc.MaxColorAttachments)
-                throw new ArgumentOutOfRangeException(nameof(index));
-            return ref Unsafe.Add(ref Slot0, index);
-        }
-    }
 }

--- a/src/Paradise.Rendering/Descriptors/RenderPassDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/RenderPassDesc.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Paradise.Rendering;
+
+/// <summary>Render pass descriptor with up to <see cref="MaxColorAttachments"/> color attachments
+/// and an optional depth attachment. Color attachments live inline (no heap allocation); use
+/// <see cref="ColorAttachments"/> to read/write a span over the live storage.</summary>
+public struct RenderPassDesc
+{
+    /// <summary>Maximum number of color attachments per pass. Matches WebGPU's required minimum (8).</summary>
+    public const int MaxColorAttachments = 8;
+
+    public ColorAttachmentBuffer Colors;
+    public int ColorAttachmentCount;
+    public DepthAttachmentDesc? Depth;
+
+    public RenderPassDesc(int colorAttachmentCount, DepthAttachmentDesc? depth = null)
+    {
+        if (colorAttachmentCount < 0 || colorAttachmentCount > MaxColorAttachments)
+            throw new ArgumentOutOfRangeException(nameof(colorAttachmentCount));
+        Colors = default;
+        ColorAttachmentCount = colorAttachmentCount;
+        Depth = depth;
+    }
+
+    /// <summary>Live span over the color attachment storage, sized by <see cref="ColorAttachmentCount"/>.</summary>
+    [UnscopedRef]
+    public Span<ColorAttachmentDesc> ColorAttachments =>
+        MemoryMarshal.CreateSpan(ref Unsafe.As<ColorAttachmentBuffer, ColorAttachmentDesc>(ref Colors), ColorAttachmentCount);
+}
+
+/// <summary>Inline storage for up to <see cref="RenderPassDesc.MaxColorAttachments"/> color attachments
+/// inside a <see cref="RenderPassDesc"/>. Access through <see cref="RenderPassDesc.ColorAttachments"/>.</summary>
+public struct ColorAttachmentBuffer
+{
+    public ColorAttachmentDesc Slot0;
+    public ColorAttachmentDesc Slot1;
+    public ColorAttachmentDesc Slot2;
+    public ColorAttachmentDesc Slot3;
+    public ColorAttachmentDesc Slot4;
+    public ColorAttachmentDesc Slot5;
+    public ColorAttachmentDesc Slot6;
+    public ColorAttachmentDesc Slot7;
+
+    /// <summary>Indexer over the inline slots. Bounds-checked against <see cref="RenderPassDesc.MaxColorAttachments"/>.</summary>
+    public ref ColorAttachmentDesc this[int index]
+    {
+        [UnscopedRef]
+        get
+        {
+            if ((uint)index >= (uint)RenderPassDesc.MaxColorAttachments)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            return ref Unsafe.Add(ref Slot0, index);
+        }
+    }
+}

--- a/src/Paradise.Rendering/Descriptors/RenderPassDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/RenderPassDesc.cs
@@ -21,6 +21,10 @@ public struct RenderPassDesc
     /// <see cref="this[int]"/> indexer or <see cref="ColorAttachments"/> span — both bound writes
     /// to <see cref="ColorAttachmentCount"/>. Direct field access is exposed for backends that
     /// need uniform layout-based marshalling.</summary>
+    /// <remarks>Direct writes to slots <c>[<see cref="ColorAttachmentCount"/>, <see cref="MaxColorAttachments"/>)</c>
+    /// are silently invisible to <see cref="this[int]"/> and <see cref="ColorAttachments"/>; only
+    /// the count-aware paths are guaranteed to surface a written attachment to the backend. Treat
+    /// this field as a marshalling escape hatch, not as a general write surface.</remarks>
     public ColorAttachmentBuffer Colors;
 
     private int _colorAttachmentCount;

--- a/src/Paradise.Rendering/Descriptors/SamplerDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/SamplerDesc.cs
@@ -1,31 +1,11 @@
 namespace Paradise.Rendering;
 
 /// <summary>Creation parameters for a GPU sampler.</summary>
-public readonly struct SamplerDesc
-{
-    public readonly string? Name;
-    public readonly SamplerAddressMode AddressU;
-    public readonly SamplerAddressMode AddressV;
-    public readonly SamplerAddressMode AddressW;
-    public readonly SamplerFilterMode MagFilter;
-    public readonly SamplerFilterMode MinFilter;
-    public readonly SamplerFilterMode MipmapFilter;
-
-    public SamplerDesc(
-        string? name,
-        SamplerAddressMode addressU,
-        SamplerAddressMode addressV,
-        SamplerAddressMode addressW,
-        SamplerFilterMode magFilter,
-        SamplerFilterMode minFilter,
-        SamplerFilterMode mipmapFilter)
-    {
-        Name = name;
-        AddressU = addressU;
-        AddressV = addressV;
-        AddressW = addressW;
-        MagFilter = magFilter;
-        MinFilter = minFilter;
-        MipmapFilter = mipmapFilter;
-    }
-}
+public readonly record struct SamplerDesc(
+    string? Name,
+    SamplerAddressMode AddressU,
+    SamplerAddressMode AddressV,
+    SamplerAddressMode AddressW,
+    SamplerFilterMode MagFilter,
+    SamplerFilterMode MinFilter,
+    SamplerFilterMode MipmapFilter);

--- a/src/Paradise.Rendering/Descriptors/SamplerDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/SamplerDesc.cs
@@ -1,0 +1,31 @@
+namespace Paradise.Rendering;
+
+/// <summary>Creation parameters for a GPU sampler.</summary>
+public readonly struct SamplerDesc
+{
+    public readonly string? Name;
+    public readonly SamplerAddressMode AddressU;
+    public readonly SamplerAddressMode AddressV;
+    public readonly SamplerAddressMode AddressW;
+    public readonly SamplerFilterMode MagFilter;
+    public readonly SamplerFilterMode MinFilter;
+    public readonly SamplerFilterMode MipmapFilter;
+
+    public SamplerDesc(
+        string? name,
+        SamplerAddressMode addressU,
+        SamplerAddressMode addressV,
+        SamplerAddressMode addressW,
+        SamplerFilterMode magFilter,
+        SamplerFilterMode minFilter,
+        SamplerFilterMode mipmapFilter)
+    {
+        Name = name;
+        AddressU = addressU;
+        AddressV = addressV;
+        AddressW = addressW;
+        MagFilter = magFilter;
+        MinFilter = minFilter;
+        MipmapFilter = mipmapFilter;
+    }
+}

--- a/src/Paradise.Rendering/Descriptors/ShaderDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/ShaderDesc.cs
@@ -4,18 +4,8 @@ namespace Paradise.Rendering;
 
 /// <summary>Raw-source shader creation parameters. Kept as the WGSL byte-stream path used by tests
 /// and any consumer not going through the Slang reflection pipeline.</summary>
-public readonly struct ShaderDesc
-{
-    public readonly string? Name;
-    public readonly ShaderStage Stage;
-    public readonly ReadOnlyMemory<byte> Source;
-    public readonly string EntryPoint;
-
-    public ShaderDesc(string? name, ShaderStage stage, ReadOnlyMemory<byte> source, string entryPoint)
-    {
-        Name = name;
-        Stage = stage;
-        Source = source;
-        EntryPoint = entryPoint;
-    }
-}
+public readonly record struct ShaderDesc(
+    string? Name,
+    ShaderStage Stage,
+    ReadOnlyMemory<byte> Source,
+    string EntryPoint);

--- a/src/Paradise.Rendering/Descriptors/ShaderDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/ShaderDesc.cs
@@ -1,11 +1,13 @@
-using System;
-
 namespace Paradise.Rendering;
 
 /// <summary>Raw-source shader creation parameters. Kept as the WGSL byte-stream path used by tests
 /// and any consumer not going through the Slang reflection pipeline.</summary>
+/// <remarks>Equality is reference-based on <paramref name="Source"/> (record-struct synthesized
+/// equality compares the array reference, not its contents). Consumers caching shader modules
+/// keyed by <see cref="ShaderDesc"/> should hash the byte content upstream, or wrap this descriptor
+/// with their own content-hashed key, before reusing it across distinct array allocations.</remarks>
 public readonly record struct ShaderDesc(
     string? Name,
     ShaderStage Stage,
-    ReadOnlyMemory<byte> Source,
+    byte[] Source,
     string EntryPoint);

--- a/src/Paradise.Rendering/Descriptors/ShaderDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/ShaderDesc.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Paradise.Rendering;
+
+/// <summary>Raw-source shader creation parameters. Kept as the WGSL byte-stream path used by tests
+/// and any consumer not going through the Slang reflection pipeline.</summary>
+public readonly struct ShaderDesc
+{
+    public readonly string? Name;
+    public readonly ShaderStage Stage;
+    public readonly ReadOnlyMemory<byte> Source;
+    public readonly string EntryPoint;
+
+    public ShaderDesc(string? name, ShaderStage stage, ReadOnlyMemory<byte> source, string entryPoint)
+    {
+        Name = name;
+        Stage = stage;
+        Source = source;
+        EntryPoint = entryPoint;
+    }
+}

--- a/src/Paradise.Rendering/Descriptors/TextureDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/TextureDesc.cs
@@ -1,0 +1,37 @@
+namespace Paradise.Rendering;
+
+/// <summary>Creation parameters for a GPU texture.</summary>
+public readonly struct TextureDesc
+{
+    public readonly string? Name;
+    public readonly uint Width;
+    public readonly uint Height;
+    public readonly uint DepthOrArrayLayers;
+    public readonly uint MipLevelCount;
+    public readonly uint SampleCount;
+    public readonly TextureDimension Dimension;
+    public readonly TextureFormat Format;
+    public readonly TextureUsage Usage;
+
+    public TextureDesc(
+        string? name,
+        uint width,
+        uint height,
+        uint depthOrArrayLayers,
+        uint mipLevelCount,
+        uint sampleCount,
+        TextureDimension dimension,
+        TextureFormat format,
+        TextureUsage usage)
+    {
+        Name = name;
+        Width = width;
+        Height = height;
+        DepthOrArrayLayers = depthOrArrayLayers;
+        MipLevelCount = mipLevelCount;
+        SampleCount = sampleCount;
+        Dimension = dimension;
+        Format = format;
+        Usage = usage;
+    }
+}

--- a/src/Paradise.Rendering/Descriptors/TextureDesc.cs
+++ b/src/Paradise.Rendering/Descriptors/TextureDesc.cs
@@ -1,37 +1,13 @@
 namespace Paradise.Rendering;
 
 /// <summary>Creation parameters for a GPU texture.</summary>
-public readonly struct TextureDesc
-{
-    public readonly string? Name;
-    public readonly uint Width;
-    public readonly uint Height;
-    public readonly uint DepthOrArrayLayers;
-    public readonly uint MipLevelCount;
-    public readonly uint SampleCount;
-    public readonly TextureDimension Dimension;
-    public readonly TextureFormat Format;
-    public readonly TextureUsage Usage;
-
-    public TextureDesc(
-        string? name,
-        uint width,
-        uint height,
-        uint depthOrArrayLayers,
-        uint mipLevelCount,
-        uint sampleCount,
-        TextureDimension dimension,
-        TextureFormat format,
-        TextureUsage usage)
-    {
-        Name = name;
-        Width = width;
-        Height = height;
-        DepthOrArrayLayers = depthOrArrayLayers;
-        MipLevelCount = mipLevelCount;
-        SampleCount = sampleCount;
-        Dimension = dimension;
-        Format = format;
-        Usage = usage;
-    }
-}
+public readonly record struct TextureDesc(
+    string? Name,
+    uint Width,
+    uint Height,
+    uint DepthOrArrayLayers,
+    uint MipLevelCount,
+    uint SampleCount,
+    TextureDimension Dimension,
+    TextureFormat Format,
+    TextureUsage Usage);

--- a/src/Paradise.Rendering/Enums.cs
+++ b/src/Paradise.Rendering/Enums.cs
@@ -1,0 +1,161 @@
+using System;
+
+namespace Paradise.Rendering;
+
+/// <summary>Native windowing platform of a <see cref="SurfaceDescriptor"/>. Selects which native handle the backend consumes.</summary>
+public enum SurfacePlatform : byte
+{
+    Unknown = 0,
+    Win32,
+    Xlib,
+    Wayland,
+    Cocoa,
+    Headless,
+}
+
+/// <summary>How a buffer may be used by the GPU. Combine with bitwise OR.</summary>
+[Flags]
+public enum BufferUsage : uint
+{
+    None = 0,
+    Vertex = 1 << 0,
+    Index = 1 << 1,
+    Uniform = 1 << 2,
+    Storage = 1 << 3,
+    CopySrc = 1 << 4,
+    CopyDst = 1 << 5,
+    Indirect = 1 << 6,
+}
+
+/// <summary>Pixel formats supported by textures and render attachments. Mirrors WebGPU's GPUTextureFormat subset used by the engine.</summary>
+public enum TextureFormat : uint
+{
+    Undefined = 0,
+    R8Unorm,
+    Rgba8Unorm,
+    Rgba8UnormSrgb,
+    Bgra8Unorm,
+    Bgra8UnormSrgb,
+    Depth32Float,
+    Depth24PlusStencil8,
+}
+
+/// <summary>How a texture may be used by the GPU. Combine with bitwise OR.</summary>
+[Flags]
+public enum TextureUsage : uint
+{
+    None = 0,
+    CopySrc = 1 << 0,
+    CopyDst = 1 << 1,
+    TextureBinding = 1 << 2,
+    StorageBinding = 1 << 3,
+    RenderAttachment = 1 << 4,
+}
+
+/// <summary>Texture dimensionality.</summary>
+public enum TextureDimension : byte
+{
+    D1 = 0,
+    D2,
+    D3,
+}
+
+/// <summary>How sampler reads beyond [0,1) are wrapped.</summary>
+public enum SamplerAddressMode : byte
+{
+    Repeat = 0,
+    MirrorRepeat,
+    ClampToEdge,
+}
+
+/// <summary>Sampler filtering for magnification, minification, and mip selection.</summary>
+public enum SamplerFilterMode : byte
+{
+    Nearest = 0,
+    Linear,
+}
+
+/// <summary>Shader stages a binding or shader module is visible to. Combine with bitwise OR.</summary>
+[Flags]
+public enum ShaderStage : uint
+{
+    None = 0,
+    Vertex = 1 << 0,
+    Fragment = 1 << 1,
+    Compute = 1 << 2,
+}
+
+/// <summary>Primitive assembly mode for a render pipeline.</summary>
+public enum PrimitiveTopology : byte
+{
+    PointList = 0,
+    LineList,
+    LineStrip,
+    TriangleList,
+    TriangleStrip,
+}
+
+/// <summary>Index buffer element width.</summary>
+public enum IndexFormat : byte
+{
+    Uint16 = 0,
+    Uint32,
+}
+
+/// <summary>What to do with the existing attachment contents at the start of a render pass.</summary>
+public enum LoadOp : byte
+{
+    Load = 0,
+    Clear,
+}
+
+/// <summary>What to do with the rendered attachment contents at the end of a render pass.</summary>
+public enum StoreOp : byte
+{
+    Store = 0,
+    Discard,
+}
+
+/// <summary>Vertex attribute element layout. Mirrors WebGPU's GPUVertexFormat.</summary>
+public enum VertexFormat : uint
+{
+    Undefined = 0,
+    Float32,
+    Float32x2,
+    Float32x3,
+    Float32x4,
+    Uint8x4,
+    Unorm8x4,
+    Sint16x2,
+    Snorm16x2,
+    Uint16x2,
+    Uint16x4,
+    Sint32,
+    Sint32x2,
+    Sint32x3,
+    Sint32x4,
+    Uint32,
+    Uint32x2,
+    Uint32x3,
+    Uint32x4,
+}
+
+/// <summary>How a vertex buffer is stepped through during a draw — per vertex or per instance.</summary>
+public enum VertexStepMode : byte
+{
+    Vertex = 0,
+    Instance,
+}
+
+/// <summary>Type of resource referenced by a bind group layout entry.</summary>
+public enum BindingResourceType : byte
+{
+    UniformBuffer = 0,
+    StorageBuffer,
+    ReadonlyStorageBuffer,
+    Sampler,
+    ComparisonSampler,
+    SampledTexture,
+    MultisampledTexture,
+    StorageTexture,
+}

--- a/src/Paradise.Rendering/Handles/Handles.cs
+++ b/src/Paradise.Rendering/Handles/Handles.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace Paradise.Rendering;
@@ -6,142 +5,52 @@ namespace Paradise.Rendering;
 // Handle structs reserve 16 bytes via [StructLayout(Size = 16)] to leave room for backend-specific
 // packing (type tag, slot generation widening, etc.) without an ABI break later. Identity is the
 // (Index, Generation) pair only — the trailing 8 bytes are intentional padding and excluded from
-// equality and hashing.
+// equality/hashing by record-struct synthesis (it only considers declared positional members).
 
 /// <summary>Opaque handle to a backend GPU buffer. Default value is invalid.</summary>
 [StructLayout(LayoutKind.Sequential, Size = 16)]
-public readonly struct BufferHandle : IEquatable<BufferHandle>
+public readonly record struct BufferHandle(uint Index, uint Generation)
 {
-    public readonly uint Index;
-    public readonly uint Generation;
-
-    public BufferHandle(uint index, uint generation)
-    {
-        Index = index;
-        Generation = generation;
-    }
-
     public bool IsValid => Generation != 0;
     public static readonly BufferHandle Invalid = default;
-
-    public bool Equals(BufferHandle other) => Index == other.Index && Generation == other.Generation;
-    public override bool Equals(object? obj) => obj is BufferHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation);
-    public static bool operator ==(BufferHandle left, BufferHandle right) => left.Equals(right);
-    public static bool operator !=(BufferHandle left, BufferHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU texture. Default value is invalid.</summary>
 [StructLayout(LayoutKind.Sequential, Size = 16)]
-public readonly struct TextureHandle : IEquatable<TextureHandle>
+public readonly record struct TextureHandle(uint Index, uint Generation)
 {
-    public readonly uint Index;
-    public readonly uint Generation;
-
-    public TextureHandle(uint index, uint generation)
-    {
-        Index = index;
-        Generation = generation;
-    }
-
     public bool IsValid => Generation != 0;
     public static readonly TextureHandle Invalid = default;
-
-    public bool Equals(TextureHandle other) => Index == other.Index && Generation == other.Generation;
-    public override bool Equals(object? obj) => obj is TextureHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation);
-    public static bool operator ==(TextureHandle left, TextureHandle right) => left.Equals(right);
-    public static bool operator !=(TextureHandle left, TextureHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU sampler. Default value is invalid.</summary>
 [StructLayout(LayoutKind.Sequential, Size = 16)]
-public readonly struct SamplerHandle : IEquatable<SamplerHandle>
+public readonly record struct SamplerHandle(uint Index, uint Generation)
 {
-    public readonly uint Index;
-    public readonly uint Generation;
-
-    public SamplerHandle(uint index, uint generation)
-    {
-        Index = index;
-        Generation = generation;
-    }
-
     public bool IsValid => Generation != 0;
     public static readonly SamplerHandle Invalid = default;
-
-    public bool Equals(SamplerHandle other) => Index == other.Index && Generation == other.Generation;
-    public override bool Equals(object? obj) => obj is SamplerHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation);
-    public static bool operator ==(SamplerHandle left, SamplerHandle right) => left.Equals(right);
-    public static bool operator !=(SamplerHandle left, SamplerHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU pipeline state object. Default value is invalid.</summary>
 [StructLayout(LayoutKind.Sequential, Size = 16)]
-public readonly struct PipelineHandle : IEquatable<PipelineHandle>
+public readonly record struct PipelineHandle(uint Index, uint Generation)
 {
-    public readonly uint Index;
-    public readonly uint Generation;
-
-    public PipelineHandle(uint index, uint generation)
-    {
-        Index = index;
-        Generation = generation;
-    }
-
     public bool IsValid => Generation != 0;
     public static readonly PipelineHandle Invalid = default;
-
-    public bool Equals(PipelineHandle other) => Index == other.Index && Generation == other.Generation;
-    public override bool Equals(object? obj) => obj is PipelineHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation);
-    public static bool operator ==(PipelineHandle left, PipelineHandle right) => left.Equals(right);
-    public static bool operator !=(PipelineHandle left, PipelineHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU shader module. Default value is invalid.</summary>
 [StructLayout(LayoutKind.Sequential, Size = 16)]
-public readonly struct ShaderHandle : IEquatable<ShaderHandle>
+public readonly record struct ShaderHandle(uint Index, uint Generation)
 {
-    public readonly uint Index;
-    public readonly uint Generation;
-
-    public ShaderHandle(uint index, uint generation)
-    {
-        Index = index;
-        Generation = generation;
-    }
-
     public bool IsValid => Generation != 0;
     public static readonly ShaderHandle Invalid = default;
-
-    public bool Equals(ShaderHandle other) => Index == other.Index && Generation == other.Generation;
-    public override bool Equals(object? obj) => obj is ShaderHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation);
-    public static bool operator ==(ShaderHandle left, ShaderHandle right) => left.Equals(right);
-    public static bool operator !=(ShaderHandle left, ShaderHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU texture view used as a render attachment. Default value is invalid.</summary>
 [StructLayout(LayoutKind.Sequential, Size = 16)]
-public readonly struct RenderViewHandle : IEquatable<RenderViewHandle>
+public readonly record struct RenderViewHandle(uint Index, uint Generation)
 {
-    public readonly uint Index;
-    public readonly uint Generation;
-
-    public RenderViewHandle(uint index, uint generation)
-    {
-        Index = index;
-        Generation = generation;
-    }
-
     public bool IsValid => Generation != 0;
     public static readonly RenderViewHandle Invalid = default;
-
-    public bool Equals(RenderViewHandle other) => Index == other.Index && Generation == other.Generation;
-    public override bool Equals(object? obj) => obj is RenderViewHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation);
-    public static bool operator ==(RenderViewHandle left, RenderViewHandle right) => left.Equals(right);
-    public static bool operator !=(RenderViewHandle left, RenderViewHandle right) => !left.Equals(right);
 }

--- a/src/Paradise.Rendering/Handles/Handles.cs
+++ b/src/Paradise.Rendering/Handles/Handles.cs
@@ -1,147 +1,147 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace Paradise.Rendering;
 
+// Handle structs reserve 16 bytes via [StructLayout(Size = 16)] to leave room for backend-specific
+// packing (type tag, slot generation widening, etc.) without an ABI break later. Identity is the
+// (Index, Generation) pair only — the trailing 8 bytes are intentional padding and excluded from
+// equality and hashing.
+
 /// <summary>Opaque handle to a backend GPU buffer. Default value is invalid.</summary>
+[StructLayout(LayoutKind.Sequential, Size = 16)]
 public readonly struct BufferHandle : IEquatable<BufferHandle>
 {
     public readonly uint Index;
     public readonly uint Generation;
-    private readonly ulong _reserved;
 
     public BufferHandle(uint index, uint generation)
     {
         Index = index;
         Generation = generation;
-        _reserved = 0;
     }
 
     public bool IsValid => Generation != 0;
     public static readonly BufferHandle Invalid = default;
 
-    public bool Equals(BufferHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public bool Equals(BufferHandle other) => Index == other.Index && Generation == other.Generation;
     public override bool Equals(object? obj) => obj is BufferHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation);
     public static bool operator ==(BufferHandle left, BufferHandle right) => left.Equals(right);
     public static bool operator !=(BufferHandle left, BufferHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU texture. Default value is invalid.</summary>
+[StructLayout(LayoutKind.Sequential, Size = 16)]
 public readonly struct TextureHandle : IEquatable<TextureHandle>
 {
     public readonly uint Index;
     public readonly uint Generation;
-    private readonly ulong _reserved;
 
     public TextureHandle(uint index, uint generation)
     {
         Index = index;
         Generation = generation;
-        _reserved = 0;
     }
 
     public bool IsValid => Generation != 0;
     public static readonly TextureHandle Invalid = default;
 
-    public bool Equals(TextureHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public bool Equals(TextureHandle other) => Index == other.Index && Generation == other.Generation;
     public override bool Equals(object? obj) => obj is TextureHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation);
     public static bool operator ==(TextureHandle left, TextureHandle right) => left.Equals(right);
     public static bool operator !=(TextureHandle left, TextureHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU sampler. Default value is invalid.</summary>
+[StructLayout(LayoutKind.Sequential, Size = 16)]
 public readonly struct SamplerHandle : IEquatable<SamplerHandle>
 {
     public readonly uint Index;
     public readonly uint Generation;
-    private readonly ulong _reserved;
 
     public SamplerHandle(uint index, uint generation)
     {
         Index = index;
         Generation = generation;
-        _reserved = 0;
     }
 
     public bool IsValid => Generation != 0;
     public static readonly SamplerHandle Invalid = default;
 
-    public bool Equals(SamplerHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public bool Equals(SamplerHandle other) => Index == other.Index && Generation == other.Generation;
     public override bool Equals(object? obj) => obj is SamplerHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation);
     public static bool operator ==(SamplerHandle left, SamplerHandle right) => left.Equals(right);
     public static bool operator !=(SamplerHandle left, SamplerHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU pipeline state object. Default value is invalid.</summary>
+[StructLayout(LayoutKind.Sequential, Size = 16)]
 public readonly struct PipelineHandle : IEquatable<PipelineHandle>
 {
     public readonly uint Index;
     public readonly uint Generation;
-    private readonly ulong _reserved;
 
     public PipelineHandle(uint index, uint generation)
     {
         Index = index;
         Generation = generation;
-        _reserved = 0;
     }
 
     public bool IsValid => Generation != 0;
     public static readonly PipelineHandle Invalid = default;
 
-    public bool Equals(PipelineHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public bool Equals(PipelineHandle other) => Index == other.Index && Generation == other.Generation;
     public override bool Equals(object? obj) => obj is PipelineHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation);
     public static bool operator ==(PipelineHandle left, PipelineHandle right) => left.Equals(right);
     public static bool operator !=(PipelineHandle left, PipelineHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU shader module. Default value is invalid.</summary>
+[StructLayout(LayoutKind.Sequential, Size = 16)]
 public readonly struct ShaderHandle : IEquatable<ShaderHandle>
 {
     public readonly uint Index;
     public readonly uint Generation;
-    private readonly ulong _reserved;
 
     public ShaderHandle(uint index, uint generation)
     {
         Index = index;
         Generation = generation;
-        _reserved = 0;
     }
 
     public bool IsValid => Generation != 0;
     public static readonly ShaderHandle Invalid = default;
 
-    public bool Equals(ShaderHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public bool Equals(ShaderHandle other) => Index == other.Index && Generation == other.Generation;
     public override bool Equals(object? obj) => obj is ShaderHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation);
     public static bool operator ==(ShaderHandle left, ShaderHandle right) => left.Equals(right);
     public static bool operator !=(ShaderHandle left, ShaderHandle right) => !left.Equals(right);
 }
 
 /// <summary>Opaque handle to a backend GPU texture view used as a render attachment. Default value is invalid.</summary>
+[StructLayout(LayoutKind.Sequential, Size = 16)]
 public readonly struct RenderViewHandle : IEquatable<RenderViewHandle>
 {
     public readonly uint Index;
     public readonly uint Generation;
-    private readonly ulong _reserved;
 
     public RenderViewHandle(uint index, uint generation)
     {
         Index = index;
         Generation = generation;
-        _reserved = 0;
     }
 
     public bool IsValid => Generation != 0;
     public static readonly RenderViewHandle Invalid = default;
 
-    public bool Equals(RenderViewHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public bool Equals(RenderViewHandle other) => Index == other.Index && Generation == other.Generation;
     public override bool Equals(object? obj) => obj is RenderViewHandle other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation);
     public static bool operator ==(RenderViewHandle left, RenderViewHandle right) => left.Equals(right);
     public static bool operator !=(RenderViewHandle left, RenderViewHandle right) => !left.Equals(right);
 }

--- a/src/Paradise.Rendering/Handles/Handles.cs
+++ b/src/Paradise.Rendering/Handles/Handles.cs
@@ -1,0 +1,147 @@
+using System;
+
+namespace Paradise.Rendering;
+
+/// <summary>Opaque handle to a backend GPU buffer. Default value is invalid.</summary>
+public readonly struct BufferHandle : IEquatable<BufferHandle>
+{
+    public readonly uint Index;
+    public readonly uint Generation;
+    private readonly ulong _reserved;
+
+    public BufferHandle(uint index, uint generation)
+    {
+        Index = index;
+        Generation = generation;
+        _reserved = 0;
+    }
+
+    public bool IsValid => Generation != 0;
+    public static readonly BufferHandle Invalid = default;
+
+    public bool Equals(BufferHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public override bool Equals(object? obj) => obj is BufferHandle other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public static bool operator ==(BufferHandle left, BufferHandle right) => left.Equals(right);
+    public static bool operator !=(BufferHandle left, BufferHandle right) => !left.Equals(right);
+}
+
+/// <summary>Opaque handle to a backend GPU texture. Default value is invalid.</summary>
+public readonly struct TextureHandle : IEquatable<TextureHandle>
+{
+    public readonly uint Index;
+    public readonly uint Generation;
+    private readonly ulong _reserved;
+
+    public TextureHandle(uint index, uint generation)
+    {
+        Index = index;
+        Generation = generation;
+        _reserved = 0;
+    }
+
+    public bool IsValid => Generation != 0;
+    public static readonly TextureHandle Invalid = default;
+
+    public bool Equals(TextureHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public override bool Equals(object? obj) => obj is TextureHandle other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public static bool operator ==(TextureHandle left, TextureHandle right) => left.Equals(right);
+    public static bool operator !=(TextureHandle left, TextureHandle right) => !left.Equals(right);
+}
+
+/// <summary>Opaque handle to a backend GPU sampler. Default value is invalid.</summary>
+public readonly struct SamplerHandle : IEquatable<SamplerHandle>
+{
+    public readonly uint Index;
+    public readonly uint Generation;
+    private readonly ulong _reserved;
+
+    public SamplerHandle(uint index, uint generation)
+    {
+        Index = index;
+        Generation = generation;
+        _reserved = 0;
+    }
+
+    public bool IsValid => Generation != 0;
+    public static readonly SamplerHandle Invalid = default;
+
+    public bool Equals(SamplerHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public override bool Equals(object? obj) => obj is SamplerHandle other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public static bool operator ==(SamplerHandle left, SamplerHandle right) => left.Equals(right);
+    public static bool operator !=(SamplerHandle left, SamplerHandle right) => !left.Equals(right);
+}
+
+/// <summary>Opaque handle to a backend GPU pipeline state object. Default value is invalid.</summary>
+public readonly struct PipelineHandle : IEquatable<PipelineHandle>
+{
+    public readonly uint Index;
+    public readonly uint Generation;
+    private readonly ulong _reserved;
+
+    public PipelineHandle(uint index, uint generation)
+    {
+        Index = index;
+        Generation = generation;
+        _reserved = 0;
+    }
+
+    public bool IsValid => Generation != 0;
+    public static readonly PipelineHandle Invalid = default;
+
+    public bool Equals(PipelineHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public override bool Equals(object? obj) => obj is PipelineHandle other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public static bool operator ==(PipelineHandle left, PipelineHandle right) => left.Equals(right);
+    public static bool operator !=(PipelineHandle left, PipelineHandle right) => !left.Equals(right);
+}
+
+/// <summary>Opaque handle to a backend GPU shader module. Default value is invalid.</summary>
+public readonly struct ShaderHandle : IEquatable<ShaderHandle>
+{
+    public readonly uint Index;
+    public readonly uint Generation;
+    private readonly ulong _reserved;
+
+    public ShaderHandle(uint index, uint generation)
+    {
+        Index = index;
+        Generation = generation;
+        _reserved = 0;
+    }
+
+    public bool IsValid => Generation != 0;
+    public static readonly ShaderHandle Invalid = default;
+
+    public bool Equals(ShaderHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public override bool Equals(object? obj) => obj is ShaderHandle other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public static bool operator ==(ShaderHandle left, ShaderHandle right) => left.Equals(right);
+    public static bool operator !=(ShaderHandle left, ShaderHandle right) => !left.Equals(right);
+}
+
+/// <summary>Opaque handle to a backend GPU texture view used as a render attachment. Default value is invalid.</summary>
+public readonly struct RenderViewHandle : IEquatable<RenderViewHandle>
+{
+    public readonly uint Index;
+    public readonly uint Generation;
+    private readonly ulong _reserved;
+
+    public RenderViewHandle(uint index, uint generation)
+    {
+        Index = index;
+        Generation = generation;
+        _reserved = 0;
+    }
+
+    public bool IsValid => Generation != 0;
+    public static readonly RenderViewHandle Invalid = default;
+
+    public bool Equals(RenderViewHandle other) => Index == other.Index && Generation == other.Generation && _reserved == other._reserved;
+    public override bool Equals(object? obj) => obj is RenderViewHandle other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Index, Generation, _reserved);
+    public static bool operator ==(RenderViewHandle left, RenderViewHandle right) => left.Equals(right);
+    public static bool operator !=(RenderViewHandle left, RenderViewHandle right) => !left.Equals(right);
+}

--- a/src/Paradise.Rendering/Paradise.Rendering.csproj
+++ b/src/Paradise.Rendering/Paradise.Rendering.csproj
@@ -14,6 +14,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>rendering;webgpu;graphics;nativeaot;game-dev</PackageTags>
+    <!-- Trimming and AOT are advertised only on the modern TFM; netstandard2.1 consumers are
+         expected to multi-target before publishing AOT, and the SDK rejects these properties
+         on netstandard. The library code itself is AOT-clean on both TFMs (no reflection,
+         source-gen-only JSON path) — the gating is purely about the SDK contract. -->
     <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsTrimmable>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>

--- a/src/Paradise.Rendering/Paradise.Rendering.csproj
+++ b/src/Paradise.Rendering/Paradise.Rendering.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net10.0</TargetFrameworks>
+    <AssemblyName>Paradise.Rendering</AssemblyName>
+    <RootNamespace>Paradise.Rendering</RootNamespace>
+    <PackageId>Paradise.Rendering</PackageId>
+    <Title>Paradise.Rendering</Title>
+    <Authors>ParadiseEngine</Authors>
+    <Description>Backend-agnostic rendering data contract: handles, descriptors, and Slang-reflection-shaped records consumed by Paradise.Rendering.* backends.</Description>
+    <Copyright>ParadiseEngine</Copyright>
+    <PackageProjectUrl>https://github.com/ParadiseEngine/ParadiseEngine</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/ParadiseEngine/ParadiseEngine</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>rendering;webgpu;graphics;nativeaot;game-dev</PackageTags>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Paradise.Rendering.Test" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paradise.Rendering/Polyfills.cs
+++ b/src/Paradise.Rendering/Polyfills.cs
@@ -3,8 +3,10 @@
 #if NETSTANDARD2_1
 namespace System.Diagnostics.CodeAnalysis
 {
+    // Targets mirror the BCL definition (.NET 7+) so this polyfill is a drop-in equivalent and
+    // a future netstandard2.1 path needing [UnscopedRef] on a constructor compiles cleanly.
     [AttributeUsage(
-        AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter,
+        AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.Constructor,
         AllowMultiple = false,
         Inherited = false)]
     internal sealed class UnscopedRefAttribute : Attribute { }

--- a/src/Paradise.Rendering/Polyfills.cs
+++ b/src/Paradise.Rendering/Polyfills.cs
@@ -1,0 +1,18 @@
+// Polyfills for attributes / types not present on netstandard2.1.
+// Compiled only when the target framework lacks them.
+#if NETSTANDARD2_1
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(
+        AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter,
+        AllowMultiple = false,
+        Inherited = false)]
+    internal sealed class UnscopedRefAttribute : Attribute { }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    // Required by C# records' init-only setters when targeting netstandard2.1.
+    internal static class IsExternalInit { }
+}
+#endif

--- a/src/Paradise.Rendering/Reflection/ShaderProgramDesc.cs
+++ b/src/Paradise.Rendering/Reflection/ShaderProgramDesc.cs
@@ -1,0 +1,48 @@
+namespace Paradise.Rendering;
+
+/// <summary>One shader module within a <see cref="ShaderProgramDesc"/>: WGSL source plus stage + entry point.</summary>
+public sealed record ShaderModuleDesc(
+    string Wgsl,
+    string EntryPoint,
+    ShaderStage Stage);
+
+/// <summary>One binding entry in a bind group layout — maps a binding slot to a resource type and visibility.</summary>
+public sealed record BindGroupLayoutEntryDesc(
+    uint Binding,
+    ShaderStage Visibility,
+    BindingResourceType Type,
+    ulong MinBufferSize = 0);
+
+/// <summary>One bind group layout (group index + ordered binding entries).</summary>
+public sealed record BindGroupLayoutDesc(
+    uint GroupIndex,
+    BindGroupLayoutEntryDesc[] Entries);
+
+/// <summary>Push constant range visible to a set of stages.</summary>
+public sealed record PushConstantRangeDesc(
+    ShaderStage Visibility,
+    uint Offset,
+    uint Size);
+
+/// <summary>Pipeline layout: ordered bind groups and push constant ranges.</summary>
+public sealed record PipelineLayoutDesc(
+    BindGroupLayoutDesc[] Groups,
+    PushConstantRangeDesc[] PushConstants);
+
+/// <summary>One vertex attribute within a buffer layout: shader location, format, byte offset.</summary>
+public sealed record VertexAttributeDesc(
+    uint ShaderLocation,
+    VertexFormat Format,
+    ulong Offset);
+
+/// <summary>One vertex buffer layout: stride, step mode, and the attributes it carries.</summary>
+public sealed record VertexBufferLayoutDesc(
+    ulong Stride,
+    VertexStepMode StepMode,
+    VertexAttributeDesc[] Attributes);
+
+/// <summary>Slang-reflection-shaped shader program: modules, pipeline layout, vertex inputs.</summary>
+public sealed record ShaderProgramDesc(
+    ShaderModuleDesc[] Modules,
+    PipelineLayoutDesc Layout,
+    VertexBufferLayoutDesc[] VertexBuffers);

--- a/src/Paradise.Rendering/Reflection/ShaderProgramDesc.cs
+++ b/src/Paradise.Rendering/Reflection/ShaderProgramDesc.cs
@@ -1,5 +1,11 @@
 namespace Paradise.Rendering;
 
+// TODO(post-M0a): switch the array-typed properties below to ImmutableArray<T> (or
+// IReadOnlyList<T>) before the contract is published. Held off in M0a because (a) the
+// fixtures + System.Text.Json source-gen pipeline both target T[] today and (b) #45's
+// Slang regression suite will exercise the contract end-to-end with real slangc output,
+// which is the right time to lock down immutability.
+
 /// <summary>One shader module within a <see cref="ShaderProgramDesc"/>: WGSL source plus stage + entry point.</summary>
 public sealed record ShaderModuleDesc(
     string Wgsl,

--- a/src/Paradise.Rendering/Reflection/ShaderReflectionJsonContext.cs
+++ b/src/Paradise.Rendering/Reflection/ShaderReflectionJsonContext.cs
@@ -5,8 +5,12 @@ namespace Paradise.Rendering;
 
 /// <summary>
 /// AOT/trim-safe <see cref="JsonSerializerContext"/> for the Slang-reflection-shaped records in
-/// <see cref="ShaderProgramDesc"/> and friends. Snake-case-lower property naming matches Slang's
-/// <c>-reflection-json</c> output schema.
+/// <see cref="ShaderProgramDesc"/> and friends. Snake-case-lower property naming targets the
+/// Slang <c>-reflection-json</c> schema as of Slang v2026.7 (the version pinned by
+/// <c>tools/slang/slang.manifest.json</c>, landing in #42). Enum values are PascalCase via
+/// <see cref="JsonStringEnumConverter"/>; if a future Slang release switches to snake_case enum
+/// members or changes the flag separator, the regression suite in #45 catches the drift before
+/// the slangc bump merges.
 /// </summary>
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,

--- a/src/Paradise.Rendering/Reflection/ShaderReflectionJsonContext.cs
+++ b/src/Paradise.Rendering/Reflection/ShaderReflectionJsonContext.cs
@@ -12,6 +12,11 @@ namespace Paradise.Rendering;
 /// members or changes the flag separator, the regression suite in #45 catches the drift before
 /// the slangc bump merges.
 /// </summary>
+/// <remarks>The round-trip behavior of this context is exercised by the test suite only on
+/// <c>net10.0</c> (the test project is single-TFM; TUnit's runner ships only for the modern
+/// runtime). On <c>netstandard2.1</c> the same source-gen and System.Text.Json 9.x package
+/// produce equivalent IL, but the equivalence is not asserted by a test. Treat <c>net10.0</c>
+/// as the authoritative consumer path until #45's regression suite widens coverage.</remarks>
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,

--- a/src/Paradise.Rendering/Reflection/ShaderReflectionJsonContext.cs
+++ b/src/Paradise.Rendering/Reflection/ShaderReflectionJsonContext.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Paradise.Rendering;
+
+/// <summary>
+/// AOT/trim-safe <see cref="JsonSerializerContext"/> for the Slang-reflection-shaped records in
+/// <see cref="ShaderProgramDesc"/> and friends. Snake-case-lower property naming matches Slang's
+/// <c>-reflection-json</c> output schema.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true,
+    WriteIndented = false)]
+[JsonSerializable(typeof(ShaderProgramDesc))]
+[JsonSerializable(typeof(ShaderModuleDesc))]
+[JsonSerializable(typeof(BindGroupLayoutEntryDesc))]
+[JsonSerializable(typeof(BindGroupLayoutDesc))]
+[JsonSerializable(typeof(PushConstantRangeDesc))]
+[JsonSerializable(typeof(PipelineLayoutDesc))]
+[JsonSerializable(typeof(VertexAttributeDesc))]
+[JsonSerializable(typeof(VertexBufferLayoutDesc))]
+public sealed partial class ShaderReflectionJsonContext : JsonSerializerContext
+{
+}

--- a/src/Paradise.Rendering/SurfaceDescriptor.cs
+++ b/src/Paradise.Rendering/SurfaceDescriptor.cs
@@ -9,9 +9,14 @@ namespace Paradise.Rendering;
 /// <para>
 /// <see cref="DisplayHandle"/> meaning is platform-specific:
 /// Wayland — <c>wl_display*</c>; Xlib — <c>Display*</c>; otherwise unused.
+/// </para>
+/// <para>
 /// <see cref="WindowHandle"/> meaning is platform-specific:
 /// Win32 — <c>HWND</c>; Wayland — <c>wl_surface*</c>; Xlib — <c>Window</c> XID;
-/// Cocoa — <c>NSWindow*</c> or <c>CAMetalLayer*</c>.
+/// Cocoa — <c>CAMetalLayer*</c> (the consumer is responsible for creating the layer on the
+/// main thread and attaching it to <c>NSWindow.contentView.layer</c> before populating this
+/// descriptor; passing a raw <c>NSWindow*</c> is unsupported because it leaves the layer-creation
+/// thread/lifetime contract ambiguous to the backend).
 /// </para>
 /// </summary>
 public readonly record struct SurfaceDescriptor(

--- a/src/Paradise.Rendering/SurfaceDescriptor.cs
+++ b/src/Paradise.Rendering/SurfaceDescriptor.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Paradise.Rendering;
+
+/// <summary>
+/// Encoding-agnostic native surface descriptor. The consumer (sample / engine glue) populates
+/// the platform tag and raw native handles read from its windowing library; the rendering
+/// backend OS-dispatches on <see cref="Platform"/> to wrap the right native surface variant.
+/// <para>
+/// <see cref="DisplayHandle"/> meaning is platform-specific:
+/// Wayland — <c>wl_display*</c>; Xlib — <c>Display*</c>; otherwise unused.
+/// <see cref="WindowHandle"/> meaning is platform-specific:
+/// Win32 — <c>HWND</c>; Wayland — <c>wl_surface*</c>; Xlib — <c>Window</c> XID;
+/// Cocoa — <c>NSWindow*</c> or <c>CAMetalLayer*</c>.
+/// </para>
+/// </summary>
+public readonly struct SurfaceDescriptor : IEquatable<SurfaceDescriptor>
+{
+    public readonly SurfacePlatform Platform;
+    public readonly IntPtr DisplayHandle;
+    public readonly IntPtr WindowHandle;
+    public readonly uint Width;
+    public readonly uint Height;
+
+    public SurfaceDescriptor(
+        SurfacePlatform platform,
+        IntPtr displayHandle,
+        IntPtr windowHandle,
+        uint width,
+        uint height)
+    {
+        Platform = platform;
+        DisplayHandle = displayHandle;
+        WindowHandle = windowHandle;
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>Headless adapter path — backend skips surface creation entirely.</summary>
+    public static SurfaceDescriptor Headless(uint width = 1, uint height = 1) =>
+        new(SurfacePlatform.Headless, IntPtr.Zero, IntPtr.Zero, width, height);
+
+    public bool Equals(SurfaceDescriptor other) =>
+        Platform == other.Platform
+        && DisplayHandle == other.DisplayHandle
+        && WindowHandle == other.WindowHandle
+        && Width == other.Width
+        && Height == other.Height;
+
+    public override bool Equals(object? obj) => obj is SurfaceDescriptor other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine((byte)Platform, DisplayHandle, WindowHandle, Width, Height);
+    public static bool operator ==(SurfaceDescriptor left, SurfaceDescriptor right) => left.Equals(right);
+    public static bool operator !=(SurfaceDescriptor left, SurfaceDescriptor right) => !left.Equals(right);
+}

--- a/src/Paradise.Rendering/SurfaceDescriptor.cs
+++ b/src/Paradise.Rendering/SurfaceDescriptor.cs
@@ -14,41 +14,14 @@ namespace Paradise.Rendering;
 /// Cocoa — <c>NSWindow*</c> or <c>CAMetalLayer*</c>.
 /// </para>
 /// </summary>
-public readonly struct SurfaceDescriptor : IEquatable<SurfaceDescriptor>
+public readonly record struct SurfaceDescriptor(
+    SurfacePlatform Platform,
+    IntPtr DisplayHandle,
+    IntPtr WindowHandle,
+    uint Width,
+    uint Height)
 {
-    public readonly SurfacePlatform Platform;
-    public readonly IntPtr DisplayHandle;
-    public readonly IntPtr WindowHandle;
-    public readonly uint Width;
-    public readonly uint Height;
-
-    public SurfaceDescriptor(
-        SurfacePlatform platform,
-        IntPtr displayHandle,
-        IntPtr windowHandle,
-        uint width,
-        uint height)
-    {
-        Platform = platform;
-        DisplayHandle = displayHandle;
-        WindowHandle = windowHandle;
-        Width = width;
-        Height = height;
-    }
-
     /// <summary>Headless adapter path — backend skips surface creation entirely.</summary>
     public static SurfaceDescriptor Headless(uint width = 1, uint height = 1) =>
         new(SurfacePlatform.Headless, IntPtr.Zero, IntPtr.Zero, width, height);
-
-    public bool Equals(SurfaceDescriptor other) =>
-        Platform == other.Platform
-        && DisplayHandle == other.DisplayHandle
-        && WindowHandle == other.WindowHandle
-        && Width == other.Width
-        && Height == other.Height;
-
-    public override bool Equals(object? obj) => obj is SurfaceDescriptor other && Equals(other);
-    public override int GetHashCode() => HashCode.Combine((byte)Platform, DisplayHandle, WindowHandle, Width, Height);
-    public static bool operator ==(SurfaceDescriptor left, SurfaceDescriptor right) => left.Equals(right);
-    public static bool operator !=(SurfaceDescriptor left, SurfaceDescriptor right) => !left.Equals(right);
 }


### PR DESCRIPTION
Closes #40

## Summary
Lands the foundation for the renderer track: a backend-agnostic `Paradise.Rendering` project (`netstandard2.1;net10.0`, `IsAotCompatible`) that future GPU backends consume through a data-shaped boundary — no `IRenderDevice`/`IBuffer`/`ITexture` interfaces, just handles, descriptors, and reflection records.

### Public surface
- **Generation-tracked handles** — `BufferHandle`, `TextureHandle`, `SamplerHandle`, `PipelineHandle`, `ShaderHandle`, `RenderViewHandle`. All `readonly struct`, `IEquatable<Self>`, default-Invalid, `IsValid` true only when `Generation != 0`.
- **`SurfaceDescriptor`** — encoding-agnostic native surface struct tagged with `SurfacePlatform` (Win32/Xlib/Wayland/Cocoa/Headless). The sample app populates raw native handles from its windowing library; the WebGPU backend in #41 OS-dispatches to the right `SurfaceSource*FFI` chained struct. `Paradise.Rendering` sees no SDL3, no Win32, no Cocoa.
- **Enums** — `BufferUsage`, `TextureFormat`, `TextureUsage`, `TextureDimension`, `SamplerAddressMode`, `SamplerFilterMode`, `ShaderStage`, `PrimitiveTopology`, `IndexFormat`, `LoadOp`, `StoreOp`, `VertexFormat`, `VertexStepMode`, `BindingResourceType`.
- **Legacy descriptors** — `BufferDesc`, `TextureDesc`, `SamplerDesc`, `ShaderDesc`, `PipelineDesc` placeholder (filled in by #42), `ColorAttachmentDesc`, `DepthAttachmentDesc`, `RenderPassDesc` with inline color attachment storage (8 slots, span accessor — works on both target frameworks via `MemoryMarshal.CreateSpan`).
- **Slang-reflection-shaped records** — `ShaderProgramDesc`, `ShaderModuleDesc`, `BindGroupLayoutEntryDesc`, `BindGroupLayoutDesc`, `PushConstantRangeDesc`, `PipelineLayoutDesc`, `VertexAttributeDesc`, `VertexBufferLayoutDesc`. AOT/trim-safe deserialization via `ShaderReflectionJsonContext` source-gen (snake_case_lower naming policy matching Slang's `-reflection-json` schema).
- **Helpers** — `ColorRgba` with common constants, `DrawCommand`/`DrawIndexedCommand`/`DispatchCommand`.

### Constraints honored
- Zero backend dependencies (no WebGPUSharp, ppy.SDL3-CS, Silk.NET, Slang, wgpu-native).
- Dual-target `netstandard2.1;net10.0`. Polyfilled `IsExternalInit` and `UnscopedRefAttribute` on netstandard2.1 only.
- Trim/AOT clean — only `System.Text.Json` source-gen, no reflection-based JSON.
- `[InternalsVisibleTo("Paradise.Rendering.Test")]`.

## Test plan
- [x] Full solution builds with `dotnet build ParadiseEngine.slnx -p:TreatWarningsAsErrors=true` (both TFMs).
- [x] All 1600 tests pass with `dotnet test ParadiseEngine.ci.slnx -p:PublishAot=false --output normal` (28 new in `Paradise.Rendering.Test`).
- [x] Each handle: `default` is `Invalid` and `!IsValid`.
- [x] Same `(Index, Generation)` -> equal + same hash.
- [x] `ColorRgba` constants verified componentwise.
- [x] `RenderPassDesc` inline storage round-trips through both indexer and `Span<ColorAttachmentDesc>` accessor; out-of-range throws.
- [x] `SurfaceDescriptor` round-trips fields for every `SurfacePlatform` variant.
- [x] Slang reflection JSON fixture (`fixtures/reflection.sample.json`) deserializes into `ShaderProgramDesc` with all bindings, push constants, and vertex attributes populated; serialize -> deserialize round-trip preserves structural equality.