### PR TITLE
[dev] Add Paradise.Rendering.WebGPU backend (M0b clear-color)

### DIFF
--- a/ParadiseEngine.slnx
+++ b/ParadiseEngine.slnx
@@ -9,6 +9,7 @@
   <Folder Name="/samples/">
     <Project Path="src/Paradise.BT.Sample/Paradise.BT.Sample.csproj" />
     <Project Path="src/Paradise.ECS.Sample/Paradise.ECS.Sample.csproj" />
+    <Project Path="src/Paradise.Rendering.Sample/Paradise.Rendering.Sample.csproj" />
   </Folder>
   <Folder Name="/sources/">
     <Project Path="src/Paradise.BLOB/Paradise.BLOB.csproj" />
@@ -20,6 +21,7 @@
     <Project Path="src/Paradise.ECS.Tag/Paradise.ECS.Tag.csproj" />
     <Project Path="src/Paradise.ECS/Paradise.ECS.csproj" />
     <Project Path="src/Paradise.Rendering/Paradise.Rendering.csproj" />
+    <Project Path="src/Paradise.Rendering.WebGPU/Paradise.Rendering.WebGPU.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="src/Paradise.BLOB.Test/Paradise.BLOB.Test.csproj" />
@@ -31,5 +33,6 @@
     <Project Path="src/Paradise.ECS.Generators.Test/Paradise.ECS.Generators.Test.csproj" />
     <Project Path="src/Paradise.ECS.Test/Paradise.ECS.Test.csproj" />
     <Project Path="src/Paradise.Rendering.Test/Paradise.Rendering.Test.csproj" />
+    <Project Path="src/Paradise.Rendering.WebGPU.Test/Paradise.Rendering.WebGPU.Test.csproj" />
   </Folder>
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,6 +8,9 @@
     <!-- Runtime helpers -->
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <!-- Rendering -->
+    <PackageVersion Include="WebGPUSharp" Version="0.5.2" />
+    <PackageVersion Include="ppy.SDL3-CS" Version="2026.320.0" />
     <!-- Testing (TUnit with Native AOT support) -->
     <PackageVersion Include="TUnit" Version="1.11.16" />
     <PackageVersion Include="Microsoft.Coyote.Test" Version="1.7.11" />

--- a/src/Paradise.Rendering.Sample/Paradise.Rendering.Sample.csproj
+++ b/src/Paradise.Rendering.Sample/Paradise.Rendering.Sample.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <PublishAot>true</PublishAot>
+    <RootNamespace>Paradise.Rendering.Sample</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Paradise.Rendering/Paradise.Rendering.csproj" />
+    <ProjectReference Include="../Paradise.Rendering.WebGPU/Paradise.Rendering.WebGPU.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ppy.SDL3-CS" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paradise.Rendering.Sample/Program.cs
+++ b/src/Paradise.Rendering.Sample/Program.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Runtime.InteropServices;
+using Paradise.Rendering;
+using Paradise.Rendering.WebGPU;
+using static SDL.SDL3;
+using SDL;
+
+namespace Paradise.Rendering.Sample;
+
+internal static class Program
+{
+    private const int InitialWidth = 640;
+    private const int InitialHeight = 480;
+
+    private static int Main(string[] args)
+    {
+        var headlessFrames = ParseHeadless(args);
+        try
+        {
+            return headlessFrames is int n ? RunHeadless(n) : RunWindowed();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Sample failed: {ex}");
+            return 1;
+        }
+    }
+
+    private static int? ParseHeadless(string[] args)
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i] != "--headless") continue;
+            if (i + 1 >= args.Length || !int.TryParse(args[i + 1], out var n) || n <= 0)
+            {
+                Console.Error.WriteLine("Usage: --headless <positive integer>");
+                return -1;
+            }
+            return n;
+        }
+        return null;
+    }
+
+    private static int RunHeadless(int frameCount)
+    {
+        if (frameCount < 0) return 1;
+
+        // SDL still needs to initialize cleanly even though no window is opened — the dummy
+        // video driver lets it succeed in headless CI containers without a display server.
+        // Using SDL_SetHint instead of Environment.SetEnvironmentVariable: native libc getenv()
+        // can cache values from process start, so the managed env var doesn't reliably reach
+        // SDL's video subsystem; SDL_SetHint writes through the SDL hint API directly.
+        SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "dummy"u8);
+
+        if (!SDL_Init(SDL_InitFlags.SDL_INIT_VIDEO))
+        {
+            Console.Error.WriteLine($"SDL_Init failed: {SDL_GetError()}");
+            return 1;
+        }
+
+        try
+        {
+            using var renderer = WebGpuRenderer.CreateHeadless(InitialWidth, InitialHeight);
+            for (var i = 0; i < frameCount; i++)
+                renderer.RenderClearFrame(ColorRgba.CornflowerBlue);
+            Console.WriteLine($"Headless mode: rendered {frameCount} clear frames against an offscreen target.");
+            return 0;
+        }
+        finally
+        {
+            SDL_Quit();
+        }
+    }
+
+    private static unsafe int RunWindowed()
+    {
+        if (!SDL_Init(SDL_InitFlags.SDL_INIT_VIDEO))
+        {
+            Console.Error.WriteLine($"SDL_Init failed: {SDL_GetError()}");
+            return 1;
+        }
+
+        SDL_Window* window = null;
+        WebGpuRenderer? renderer = null;
+        try
+        {
+            window = SDL_CreateWindow("Paradise.Rendering — Clear Color", InitialWidth, InitialHeight, SDL_WindowFlags.SDL_WINDOW_RESIZABLE);
+            if (window == null)
+            {
+                Console.Error.WriteLine($"SDL_CreateWindow failed: {SDL_GetError()}");
+                return 1;
+            }
+
+            var surfaceDesc = BuildSurfaceDescriptor(window);
+            renderer = new WebGpuRenderer(in surfaceDesc);
+
+            var quit = false;
+            SDL_Event ev;
+            while (!quit)
+            {
+                while (SDL_PollEvent(&ev))
+                {
+                    var type = (SDL_EventType)ev.type;
+                    if (type == SDL_EventType.SDL_EVENT_QUIT)
+                    {
+                        quit = true;
+                    }
+                    else if (type == SDL_EventType.SDL_EVENT_WINDOW_CLOSE_REQUESTED)
+                    {
+                        quit = true;
+                    }
+                    else if (type == SDL_EventType.SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED ||
+                             type == SDL_EventType.SDL_EVENT_WINDOW_RESIZED)
+                    {
+                        var w = ev.window.data1;
+                        var h = ev.window.data2;
+                        if (w > 0 && h > 0)
+                            renderer.Resize((uint)w, (uint)h);
+                    }
+                }
+                renderer.RenderClearFrame(ColorRgba.CornflowerBlue);
+            }
+
+            return 0;
+        }
+        finally
+        {
+            renderer?.Dispose();
+            if (window != null) SDL_DestroyWindow(window);
+            SDL_Quit();
+        }
+    }
+
+    private static unsafe SurfaceDescriptor BuildSurfaceDescriptor(SDL_Window* window)
+    {
+        var props = SDL_GetWindowProperties(window);
+
+        int w = 0, h = 0;
+        SDL_GetWindowSizeInPixels(window, &w, &h);
+        var width = (uint)Math.Max(1, w);
+        var height = (uint)Math.Max(1, h);
+
+        if (OperatingSystem.IsWindows())
+        {
+            var hwnd = SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WIN32_HWND_POINTER, IntPtr.Zero);
+            return new SurfaceDescriptor(SurfacePlatform.Win32, IntPtr.Zero, hwnd, width, height);
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            // SDL3 exposes the NSWindow*, not a CAMetalLayer*. The minimal sample passes the
+            // window pointer; full Cocoa hookup (creating CAMetalLayer on the main thread and
+            // attaching it to the content view) is documented as a known macOS constraint in
+            // the issue spec and is left to be exercised when M0b runs on macOS.
+            var nsWindow = SDL_GetPointerProperty(props, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, IntPtr.Zero);
+            return new SurfaceDescriptor(SurfacePlatform.Cocoa, IntPtr.Zero, nsWindow, width, height);
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            var wlDisplay = SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER, IntPtr.Zero);
+            if (wlDisplay != IntPtr.Zero)
+            {
+                var wlSurface = SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER, IntPtr.Zero);
+                return new SurfaceDescriptor(SurfacePlatform.Wayland, wlDisplay, wlSurface, width, height);
+            }
+
+            var x11Display = SDL_GetPointerProperty(props, SDL_PROP_WINDOW_X11_DISPLAY_POINTER, IntPtr.Zero);
+            var x11Window = SDL_GetNumberProperty(props, SDL_PROP_WINDOW_X11_WINDOW_NUMBER, 0);
+            return new SurfaceDescriptor(SurfacePlatform.Xlib, x11Display, (IntPtr)x11Window, width, height);
+        }
+
+        throw new PlatformNotSupportedException(
+            $"Surface mapping for the current OS ({RuntimeInformation.OSDescription}) is not implemented; " +
+            "use --headless on this platform.");
+    }
+}

--- a/src/Paradise.Rendering.Sample/Program.cs
+++ b/src/Paradise.Rendering.Sample/Program.cs
@@ -148,12 +148,15 @@ internal static class Program
 
         if (OperatingSystem.IsMacOS())
         {
-            // SDL3 exposes the NSWindow*, not a CAMetalLayer*. The minimal sample passes the
-            // window pointer; full Cocoa hookup (creating CAMetalLayer on the main thread and
-            // attaching it to the content view) is documented as a known macOS constraint in
-            // the issue spec and is left to be exercised when M0b runs on macOS.
-            var nsWindow = SDL_GetPointerProperty(props, SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, IntPtr.Zero);
-            return new SurfaceDescriptor(SurfacePlatform.Cocoa, IntPtr.Zero, nsWindow, width, height);
+            // The Cocoa surface path expects a CAMetalLayer*, but SDL3 only exposes the
+            // NSWindow*. Wiring CAMetalLayer (creation on the main thread + attachment to the
+            // NSWindow content view) is out of scope for M0b per the issue spec. Refuse the
+            // windowed path explicitly rather than feeding the wrong pointer to Dawn — the
+            // headless adapter path (--headless N) covers macOS for now.
+            throw new PlatformNotSupportedException(
+                "Windowed macOS is not yet wired: SDL3 exposes NSWindow* but the Cocoa surface " +
+                "path requires a CAMetalLayer*. CAMetalLayer creation and attachment will land " +
+                "with full Cocoa support; use --headless N on macOS for now.");
         }
 
         if (OperatingSystem.IsLinux())

--- a/src/Paradise.Rendering.WebGPU.Test/HeadlessSmokeTests.cs
+++ b/src/Paradise.Rendering.WebGPU.Test/HeadlessSmokeTests.cs
@@ -3,26 +3,43 @@ using TUnit.Core;
 namespace Paradise.Rendering.WebGPU.Test;
 
 /// <summary>Smoke tests that exercise the headless adapter path. These hit live Dawn natives via
-/// WebGPUSharp; if no Vulkan/Metal/DX12 backend is available (no GPU, no lavapipe on Linux CI)
-/// the tests skip cleanly via <see cref="Skip.Test(string)"/> on <see cref="AdapterUnavailableException"/>
-/// rather than failing. Device-creation or any other backend failure surfaces as a real test
-/// failure — only adapter unavailability is treated as "not applicable on this host". The AOT
-/// publish in CI is the load-bearing M0 acceptance signal; these are belt-and-suspenders.</summary>
+/// WebGPUSharp; if WebGPU is not exercisable on this host the tests skip cleanly via
+/// <see cref="Skip.Test(string)"/> rather than failing. Two skip conditions:
+/// <list type="bullet">
+/// <item><see cref="AdapterUnavailableException"/> — Dawn loaded but returned no adapter (no
+/// Vulkan/Metal/DX12 backend, e.g. CI without lavapipe + libvulkan1).</item>
+/// <item><see cref="DllNotFoundException"/> — Dawn's <c>webgpu_dawn</c> native (or one of its
+/// transitive dependencies, notably <c>libc++.so.1</c> on Linux) cannot be loaded by the runtime.
+/// Equivalent "WebGPU not available on this host" condition.</item>
+/// </list>
+/// Device-creation or any other backend failure surfaces as a real test failure — only
+/// host-environment unavailability is treated as "not applicable here". The AOT publish in CI is
+/// the load-bearing M0 acceptance signal; these are belt-and-suspenders.</summary>
 public class HeadlessSmokeTests
 {
-    [Test]
-    public async Task headless_renderer_initializes_and_disposes()
+    private static WebGpuRenderer? TryCreateHeadlessOrSkip(uint width, uint height)
     {
-        WebGpuRenderer? renderer;
         try
         {
-            renderer = WebGpuRenderer.CreateHeadless(64, 64);
+            return WebGpuRenderer.CreateHeadless(width, height);
         }
         catch (AdapterUnavailableException ex)
         {
             Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
-            return;
+            return null;
         }
+        catch (DllNotFoundException ex)
+        {
+            Skip.Test($"WebGPU native library not loadable on this host: {ex.Message}");
+            return null;
+        }
+    }
+
+    [Test]
+    public async Task headless_renderer_initializes_and_disposes()
+    {
+        var renderer = TryCreateHeadlessOrSkip(64, 64);
+        if (renderer is null) return;
 
         try
         {
@@ -37,16 +54,8 @@ public class HeadlessSmokeTests
     [Test]
     public async Task headless_renderer_renders_clear_frames()
     {
-        WebGpuRenderer? renderer;
-        try
-        {
-            renderer = WebGpuRenderer.CreateHeadless(32, 32);
-        }
-        catch (AdapterUnavailableException ex)
-        {
-            Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
-            return;
-        }
+        var renderer = TryCreateHeadlessOrSkip(32, 32);
+        if (renderer is null) return;
 
         try
         {
@@ -63,16 +72,8 @@ public class HeadlessSmokeTests
     [Test]
     public async Task headless_renderer_resize_resizes_offscreen_target()
     {
-        WebGpuRenderer? renderer;
-        try
-        {
-            renderer = WebGpuRenderer.CreateHeadless(16, 16);
-        }
-        catch (AdapterUnavailableException ex)
-        {
-            Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
-            return;
-        }
+        var renderer = TryCreateHeadlessOrSkip(16, 16);
+        if (renderer is null) return;
 
         try
         {

--- a/src/Paradise.Rendering.WebGPU.Test/HeadlessSmokeTests.cs
+++ b/src/Paradise.Rendering.WebGPU.Test/HeadlessSmokeTests.cs
@@ -4,8 +4,10 @@ namespace Paradise.Rendering.WebGPU.Test;
 
 /// <summary>Smoke tests that exercise the headless adapter path. These hit live Dawn natives via
 /// WebGPUSharp; if no Vulkan/Metal/DX12 backend is available (no GPU, no lavapipe on Linux CI)
-/// the tests skip cleanly via <see cref="Skip.When"/> rather than failing. The AOT publish in CI
-/// is the load-bearing M0 acceptance signal — these are belt-and-suspenders.</summary>
+/// the tests skip cleanly via <see cref="Skip.Test(string)"/> on <see cref="AdapterUnavailableException"/>
+/// rather than failing. Device-creation or any other backend failure surfaces as a real test
+/// failure — only adapter unavailability is treated as "not applicable on this host". The AOT
+/// publish in CI is the load-bearing M0 acceptance signal; these are belt-and-suspenders.</summary>
 public class HeadlessSmokeTests
 {
     [Test]
@@ -16,7 +18,7 @@ public class HeadlessSmokeTests
         {
             renderer = WebGpuRenderer.CreateHeadless(64, 64);
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("adapter", StringComparison.OrdinalIgnoreCase))
+        catch (AdapterUnavailableException ex)
         {
             Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
             return;
@@ -40,7 +42,7 @@ public class HeadlessSmokeTests
         {
             renderer = WebGpuRenderer.CreateHeadless(32, 32);
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("adapter", StringComparison.OrdinalIgnoreCase))
+        catch (AdapterUnavailableException ex)
         {
             Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
             return;
@@ -66,7 +68,7 @@ public class HeadlessSmokeTests
         {
             renderer = WebGpuRenderer.CreateHeadless(16, 16);
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("adapter", StringComparison.OrdinalIgnoreCase))
+        catch (AdapterUnavailableException ex)
         {
             Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
             return;

--- a/src/Paradise.Rendering.WebGPU.Test/HeadlessSmokeTests.cs
+++ b/src/Paradise.Rendering.WebGPU.Test/HeadlessSmokeTests.cs
@@ -1,0 +1,93 @@
+using TUnit.Core;
+
+namespace Paradise.Rendering.WebGPU.Test;
+
+/// <summary>Smoke tests that exercise the headless adapter path. These hit live Dawn natives via
+/// WebGPUSharp; if no Vulkan/Metal/DX12 backend is available (no GPU, no lavapipe on Linux CI)
+/// the tests skip cleanly via <see cref="Skip.When"/> rather than failing. The AOT publish in CI
+/// is the load-bearing M0 acceptance signal — these are belt-and-suspenders.</summary>
+public class HeadlessSmokeTests
+{
+    [Test]
+    public async Task headless_renderer_initializes_and_disposes()
+    {
+        WebGpuRenderer? renderer;
+        try
+        {
+            renderer = WebGpuRenderer.CreateHeadless(64, 64);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("adapter", StringComparison.OrdinalIgnoreCase))
+        {
+            Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
+            return;
+        }
+
+        try
+        {
+            await Assert.That(renderer).IsNotNull();
+        }
+        finally
+        {
+            renderer.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task headless_renderer_renders_clear_frames()
+    {
+        WebGpuRenderer? renderer;
+        try
+        {
+            renderer = WebGpuRenderer.CreateHeadless(32, 32);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("adapter", StringComparison.OrdinalIgnoreCase))
+        {
+            Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
+            return;
+        }
+
+        try
+        {
+            for (var i = 0; i < 3; i++)
+                renderer.RenderClearFrame(ColorRgba.CornflowerBlue);
+            await Assert.That(renderer).IsNotNull();
+        }
+        finally
+        {
+            renderer.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task headless_renderer_resize_resizes_offscreen_target()
+    {
+        WebGpuRenderer? renderer;
+        try
+        {
+            renderer = WebGpuRenderer.CreateHeadless(16, 16);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("adapter", StringComparison.OrdinalIgnoreCase))
+        {
+            Skip.Test($"No WebGPU adapter available on this host: {ex.Message}");
+            return;
+        }
+
+        try
+        {
+            renderer.Resize(128, 96);
+            renderer.RenderClearFrame(ColorRgba.Black);
+            await Assert.That(renderer).IsNotNull();
+        }
+        finally
+        {
+            renderer.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task surface_ctor_rejects_headless_platform()
+    {
+        var desc = SurfaceDescriptor.Headless();
+        await Assert.That(() => new WebGpuRenderer(in desc)).Throws<ArgumentException>();
+    }
+}

--- a/src/Paradise.Rendering.WebGPU.Test/Paradise.Rendering.WebGPU.Test.csproj
+++ b/src/Paradise.Rendering.WebGPU.Test/Paradise.Rendering.WebGPU.Test.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Paradise.Rendering.WebGPU.Test</AssemblyName>
+    <RootNamespace>Paradise.Rendering.WebGPU.Test</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paradise.Rendering\Paradise.Rendering.csproj" />
+    <ProjectReference Include="..\Paradise.Rendering.WebGPU\Paradise.Rendering.WebGPU.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Paradise.Rendering.WebGPU.Test/Usings.cs
+++ b/src/Paradise.Rendering.WebGPU.Test/Usings.cs
@@ -1,0 +1,4 @@
+global using System;
+global using System.Threading.Tasks;
+global using Paradise.Rendering;
+global using Paradise.Rendering.WebGPU;

--- a/src/Paradise.Rendering.WebGPU/AdapterUnavailableException.cs
+++ b/src/Paradise.Rendering.WebGPU/AdapterUnavailableException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Paradise.Rendering.WebGPU;
+
+/// <summary>Thrown when the WebGPU instance cannot acquire any adapter — typically because the
+/// host has no Vulkan/Metal/DX12 backend available (CI without lavapipe, headless container
+/// without GPU drivers). Distinct from generic <see cref="InvalidOperationException"/> so callers
+/// (notably CI smoke tests) can skip cleanly on adapter unavailability without also skipping real
+/// device-create regressions.</summary>
+public sealed class AdapterUnavailableException : Exception
+{
+    public AdapterUnavailableException(string message) : base(message) { }
+    public AdapterUnavailableException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/src/Paradise.Rendering.WebGPU/Internal/SlotTable.cs
+++ b/src/Paradise.Rendering.WebGPU/Internal/SlotTable.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+
+namespace Paradise.Rendering.WebGPU.Internal;
+
+/// <summary>Generation-tracked slot allocator mapping <c>(uint Index, uint Generation)</c>
+/// handles to backend objects of type <typeparamref name="T"/>. Generation 0 is reserved as the
+/// invalid sentinel — every issued handle has <c>Generation &gt;= 1</c>, matching the
+/// <c>IsValid</c> contract on <c>Paradise.Rendering</c>'s handle structs.</summary>
+internal sealed class SlotTable<T> where T : class
+{
+    private readonly List<Slot> _slots = new();
+    private readonly Stack<uint> _free = new();
+
+    private struct Slot
+    {
+        public T? Value;
+        public uint Generation;
+    }
+
+    public int Count => _slots.Count - _free.Count;
+
+    public (uint Index, uint Generation) Add(T value)
+    {
+        if (_free.TryPop(out var index))
+        {
+            ref var slot = ref System.Runtime.InteropServices.CollectionsMarshal.AsSpan(_slots)[(int)index];
+            slot.Value = value;
+            return (index, slot.Generation);
+        }
+
+        index = (uint)_slots.Count;
+        _slots.Add(new Slot { Value = value, Generation = 1 });
+        return (index, 1u);
+    }
+
+    public bool TryGet(uint index, uint generation, out T value)
+    {
+        if (index >= (uint)_slots.Count)
+        {
+            value = null!;
+            return false;
+        }
+
+        var slot = _slots[(int)index];
+        if (slot.Generation != generation || slot.Value is null)
+        {
+            value = null!;
+            return false;
+        }
+
+        value = slot.Value;
+        return true;
+    }
+
+    public bool Remove(uint index, uint generation)
+    {
+        if (index >= (uint)_slots.Count) return false;
+        ref var slot = ref System.Runtime.InteropServices.CollectionsMarshal.AsSpan(_slots)[(int)index];
+        if (slot.Generation != generation || slot.Value is null) return false;
+
+        slot.Value = null;
+        // Bump generation so a future allocation in this slot produces a distinct handle and stale
+        // handles to the removed entry stop resolving. Skip generation 0 on wraparound — that
+        // value is the invalid sentinel for handle structs.
+        unchecked { slot.Generation++; }
+        if (slot.Generation == 0) slot.Generation = 1;
+
+        _free.Push(index);
+        return true;
+    }
+
+    public void Clear()
+    {
+        _slots.Clear();
+        _free.Clear();
+    }
+}

--- a/src/Paradise.Rendering.WebGPU/Internal/SurfaceFactory.cs
+++ b/src/Paradise.Rendering.WebGPU/Internal/SurfaceFactory.cs
@@ -1,0 +1,80 @@
+using System;
+using WebGpuSharp.FFI;
+using WgInstance = WebGpuSharp.Instance;
+using WgSurface = WebGpuSharp.Surface;
+using WgSurfaceDescriptor = WebGpuSharp.SurfaceDescriptor;
+
+namespace Paradise.Rendering.WebGPU.Internal;
+
+/// <summary>OS-dispatched native surface creation. Maps a <see cref="SurfaceDescriptor"/> from
+/// <c>Paradise.Rendering</c> onto the appropriate WebGPUSharp <c>SurfaceSource*FFI</c> chained
+/// struct. The headless path is rejected here: callers must skip surface creation entirely and
+/// take the headless adapter path in <see cref="WebGpuDevice"/>.</summary>
+internal static unsafe class SurfaceFactory
+{
+    public static WgSurface Create(WgInstance instance, in SurfaceDescriptor desc)
+    {
+        return desc.Platform switch
+        {
+            SurfacePlatform.Win32 => CreateWin32(instance, desc.WindowHandle),
+            SurfacePlatform.Xlib => CreateXlib(instance, desc.DisplayHandle, desc.WindowHandle),
+            SurfacePlatform.Wayland => CreateWayland(instance, desc.DisplayHandle, desc.WindowHandle),
+            SurfacePlatform.Cocoa => CreateMetalLayer(instance, desc.WindowHandle),
+            SurfacePlatform.Headless => throw new InvalidOperationException(
+                "Headless surfaces must skip CreateSurface entirely and use the headless adapter path."),
+            _ => throw new NotSupportedException($"Surface platform '{desc.Platform}' is not supported by the WebGPU backend."),
+        };
+    }
+
+    private static WgSurface CreateWin32(WgInstance instance, IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero) throw new ArgumentException("Win32 surface requires a non-null HWND.", nameof(hwnd));
+        var src = new SurfaceSourceWindowsHWNDFFI
+        {
+            // Hinstance is optional in Dawn — leaving it null lets the implementation pick.
+            Hinstance = null,
+            Hwnd = (void*)hwnd,
+        };
+        return CreateOrThrow(instance, new WgSurfaceDescriptor(ref src), nameof(SurfacePlatform.Win32));
+    }
+
+    private static WgSurface CreateXlib(WgInstance instance, IntPtr display, IntPtr window)
+    {
+        if (display == IntPtr.Zero) throw new ArgumentException("Xlib surface requires a non-null Display*.", nameof(display));
+        if (window == IntPtr.Zero) throw new ArgumentException("Xlib surface requires a non-null Window XID.", nameof(window));
+        var src = new SurfaceSourceXlibWindowFFI
+        {
+            Display = (void*)display,
+            Window = (ulong)window.ToInt64(),
+        };
+        return CreateOrThrow(instance, new WgSurfaceDescriptor(ref src), nameof(SurfacePlatform.Xlib));
+    }
+
+    private static WgSurface CreateWayland(WgInstance instance, IntPtr display, IntPtr surface)
+    {
+        if (display == IntPtr.Zero) throw new ArgumentException("Wayland surface requires a non-null wl_display*.", nameof(display));
+        if (surface == IntPtr.Zero) throw new ArgumentException("Wayland surface requires a non-null wl_surface*.", nameof(surface));
+        var src = new SurfaceSourceWaylandSurfaceFFI
+        {
+            Display = (void*)display,
+            Surface = (void*)surface,
+        };
+        return CreateOrThrow(instance, new WgSurfaceDescriptor(ref src), nameof(SurfacePlatform.Wayland));
+    }
+
+    private static WgSurface CreateMetalLayer(WgInstance instance, IntPtr metalLayer)
+    {
+        if (metalLayer == IntPtr.Zero) throw new ArgumentException("Cocoa surface requires a non-null CAMetalLayer*.", nameof(metalLayer));
+        var src = new SurfaceSourceMetalLayerFFI
+        {
+            Layer = (void*)metalLayer,
+        };
+        return CreateOrThrow(instance, new WgSurfaceDescriptor(ref src), nameof(SurfacePlatform.Cocoa));
+    }
+
+    private static WgSurface CreateOrThrow(WgInstance instance, WgSurfaceDescriptor descriptor, string platformLabel)
+    {
+        return instance.CreateSurface(descriptor)
+            ?? throw new InvalidOperationException($"Instance.CreateSurface returned null for platform '{platformLabel}'.");
+    }
+}

--- a/src/Paradise.Rendering.WebGPU/Internal/SurfaceState.cs
+++ b/src/Paradise.Rendering.WebGPU/Internal/SurfaceState.cs
@@ -1,0 +1,71 @@
+using System;
+using WgSurface = WebGpuSharp.Surface;
+using WgTextureFormat = WebGpuSharp.TextureFormat;
+using WgTextureUsage = WebGpuSharp.TextureUsage;
+using WgSurfaceConfiguration = WebGpuSharp.SurfaceConfiguration;
+using WgCompositeAlphaMode = WebGpuSharp.CompositeAlphaMode;
+using WgPresentMode = WebGpuSharp.PresentMode;
+
+namespace Paradise.Rendering.WebGPU.Internal;
+
+/// <summary>Owns a configured WebGPU <see cref="WgSurface"/>: chosen swapchain format, current
+/// width/height, and reconfiguration on resize.</summary>
+internal sealed class SurfaceState : IDisposable
+{
+    private readonly WebGpuDevice _device;
+    private readonly WgSurface _surface;
+    private bool _disposed;
+
+    public WgTextureFormat Format { get; private set; }
+    public uint Width { get; private set; }
+    public uint Height { get; private set; }
+
+    public WgSurface Native => _surface;
+
+    public SurfaceState(WebGpuDevice device, WgSurface surface, uint width, uint height)
+    {
+        _device = device;
+        _surface = surface;
+        Width = width == 0 ? 1 : width;
+        Height = height == 0 ? 1 : height;
+
+        var caps = surface.GetCapabilities(device.Adapter)
+            ?? throw new InvalidOperationException("Surface.GetCapabilities returned null for the chosen adapter.");
+        var formats = caps.Formats;
+        Format = formats.Length > 0 ? formats[0] : WgTextureFormat.BGRA8Unorm;
+
+        Configure();
+    }
+
+    public void Resize(uint width, uint height)
+    {
+        if (width == 0) width = 1;
+        if (height == 0) height = 1;
+        if (width == Width && height == Height) return;
+        Width = width;
+        Height = height;
+        Configure();
+    }
+
+    private void Configure()
+    {
+        var config = new WgSurfaceConfiguration
+        {
+            Device = _device.Device,
+            Format = Format,
+            Usage = WgTextureUsage.RenderAttachment,
+            AlphaMode = WgCompositeAlphaMode.Auto,
+            PresentMode = WgPresentMode.Fifo,
+            Width = Width,
+            Height = Height,
+        };
+        _surface.Configure(in config);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _surface.Unconfigure();
+    }
+}

--- a/src/Paradise.Rendering.WebGPU/Internal/SurfaceState.cs
+++ b/src/Paradise.Rendering.WebGPU/Internal/SurfaceState.cs
@@ -47,6 +47,11 @@ internal sealed class SurfaceState : IDisposable
         Configure();
     }
 
+    /// <summary>Re-apply the current configuration without changing dimensions. Used by the
+    /// renderer when <c>GetCurrentTexture</c> reports <c>Outdated</c> / <c>Lost</c> — the
+    /// swapchain itself needs to be rebuilt even though the requested size hasn't changed.</summary>
+    public void Reconfigure() => Configure();
+
     private void Configure()
     {
         var config = new WgSurfaceConfiguration

--- a/src/Paradise.Rendering.WebGPU/Internal/WebGpuDevice.cs
+++ b/src/Paradise.Rendering.WebGPU/Internal/WebGpuDevice.cs
@@ -1,0 +1,91 @@
+using System;
+using WgInstance = WebGpuSharp.Instance;
+using WgAdapter = WebGpuSharp.Adapter;
+using WgDevice = WebGpuSharp.Device;
+using WgQueue = WebGpuSharp.Queue;
+using WgSurface = WebGpuSharp.Surface;
+using WgRequestAdapterOptions = WebGpuSharp.RequestAdapterOptions;
+using WgDeviceDescriptor = WebGpuSharp.DeviceDescriptor;
+using WgPowerPreference = WebGpuSharp.PowerPreference;
+using WgFeatureLevel = WebGpuSharp.FeatureLevel;
+
+namespace Paradise.Rendering.WebGPU.Internal;
+
+/// <summary>Owns the long-lived WebGPU instance/adapter/device/queue chain. Constructed once per
+/// <see cref="WebGpuRenderer"/>. Adapter selection takes an optional compatible <see cref="WgSurface"/>
+/// — pass <c>null</c> to drive the headless adapter path (no swapchain).</summary>
+internal sealed class WebGpuDevice : IDisposable
+{
+    public WgInstance Instance { get; }
+    public WgAdapter Adapter { get; }
+    public WgDevice Device { get; }
+    public WgQueue Queue { get; }
+
+    private bool _disposed;
+
+    private WebGpuDevice(WgInstance instance, WgAdapter adapter, WgDevice device, WgQueue queue)
+    {
+        Instance = instance;
+        Adapter = adapter;
+        Device = device;
+        Queue = queue;
+    }
+
+    public static WebGpuDevice Create(WgInstance instance, WgSurface? compatibleSurface)
+    {
+        const ulong AdapterTimeoutNs = 10_000_000_000UL; // 10s — generous for cold first-run on CI
+
+        // CompatibleSurface is a required init member on RequestAdapterOptions, so two literals
+        // is simpler than reflection — picking the headless path means leaving it default-null.
+        WgAdapter? adapter;
+        if (compatibleSurface is not null)
+        {
+            var opts = new WgRequestAdapterOptions
+            {
+                CompatibleSurface = compatibleSurface,
+                PowerPreference = WgPowerPreference.HighPerformance,
+                FeatureLevel = WgFeatureLevel.Core,
+            };
+            adapter = instance.RequestAdapterSync(in opts, AdapterTimeoutNs);
+        }
+        else
+        {
+            var opts = new WgRequestAdapterOptions
+            {
+                CompatibleSurface = null!,
+                PowerPreference = WgPowerPreference.HighPerformance,
+                FeatureLevel = WgFeatureLevel.Core,
+            };
+            adapter = instance.RequestAdapterSync(in opts, AdapterTimeoutNs);
+        }
+
+        if (adapter is null)
+            throw new InvalidOperationException(
+                "Failed to acquire a WebGPU adapter. On Linux without a GPU, install mesa-vulkan-drivers / libvulkan1 (lavapipe) for headless support.");
+
+        var deviceDesc = new WgDeviceDescriptor
+        {
+            Label = "Paradise.Rendering.WebGPU",
+            UncapturedErrorCallback = static (type, message) =>
+            {
+                var text = message.Length == 0 ? "(no message)" : System.Text.Encoding.UTF8.GetString(message);
+                Console.Error.WriteLine($"[WebGPU] {type}: {text}");
+            },
+        };
+
+        var device = adapter.RequestDeviceSync(in deviceDesc, AdapterTimeoutNs)
+            ?? throw new InvalidOperationException("Failed to create a WebGPU device from the requested adapter.");
+
+        var queue = device.GetQueue();
+        return new WebGpuDevice(instance, adapter, device, queue);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        // WebGPUSharp's safe wrappers release native handles via finalizers; explicit teardown
+        // ordering here is mostly documentation. The instance must outlive surfaces and devices,
+        // so the owning Renderer disposes those first.
+    }
+}

--- a/src/Paradise.Rendering.WebGPU/Internal/WebGpuDevice.cs
+++ b/src/Paradise.Rendering.WebGPU/Internal/WebGpuDevice.cs
@@ -60,8 +60,8 @@ internal sealed class WebGpuDevice : IDisposable
         }
 
         if (adapter is null)
-            throw new InvalidOperationException(
-                "Failed to acquire a WebGPU adapter. On Linux without a GPU, install mesa-vulkan-drivers / libvulkan1 (lavapipe) for headless support.");
+            throw new AdapterUnavailableException(
+                "No WebGPU adapter available. On Linux without a GPU, install mesa-vulkan-drivers / libvulkan1 (lavapipe) for headless support.");
 
         var deviceDesc = new WgDeviceDescriptor
         {
@@ -74,7 +74,7 @@ internal sealed class WebGpuDevice : IDisposable
         };
 
         var device = adapter.RequestDeviceSync(in deviceDesc, AdapterTimeoutNs)
-            ?? throw new InvalidOperationException("Failed to create a WebGPU device from the requested adapter.");
+            ?? throw new InvalidOperationException("WebGPU device creation failed.");
 
         var queue = device.GetQueue();
         return new WebGpuDevice(instance, adapter, device, queue);

--- a/src/Paradise.Rendering.WebGPU/Paradise.Rendering.WebGPU.csproj
+++ b/src/Paradise.Rendering.WebGPU/Paradise.Rendering.WebGPU.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>Paradise.Rendering.WebGPU</AssemblyName>
+    <RootNamespace>Paradise.Rendering.WebGPU</RootNamespace>
+    <PackageId>Paradise.Rendering.WebGPU</PackageId>
+    <Title>Paradise.Rendering.WebGPU</Title>
+    <Authors>ParadiseEngine</Authors>
+    <Description>WebGPU (Dawn) backend for Paradise.Rendering. Owns native instance/adapter/device/surface state; consumers see only Paradise.Rendering handle/descriptor types.</Description>
+    <Copyright>ParadiseEngine</Copyright>
+    <PackageProjectUrl>https://github.com/ParadiseEngine/ParadiseEngine</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/ParadiseEngine/ParadiseEngine</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>rendering;webgpu;dawn;graphics;nativeaot;game-dev</PackageTags>
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Paradise.Rendering/Paradise.Rendering.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WebGPUSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Paradise.Rendering.WebGPU.Test" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paradise.Rendering.WebGPU/WebGpuRenderer.cs
+++ b/src/Paradise.Rendering.WebGPU/WebGpuRenderer.cs
@@ -1,0 +1,172 @@
+using System;
+using Paradise.Rendering.WebGPU.Internal;
+using WgWebGPU = WebGpuSharp.WebGPU;
+using WgTextureView = WebGpuSharp.TextureView;
+using WgTexture = WebGpuSharp.Texture;
+using WgTextureDescriptor = WebGpuSharp.TextureDescriptor;
+using WgTextureFormat = WebGpuSharp.TextureFormat;
+using WgTextureUsage = WebGpuSharp.TextureUsage;
+using WgTextureDimension = WebGpuSharp.TextureDimension;
+using WgRenderPassDescriptor = WebGpuSharp.RenderPassDescriptor;
+using WgRenderPassColorAttachment = WebGpuSharp.RenderPassColorAttachment;
+using WgLoadOp = WebGpuSharp.LoadOp;
+using WgStoreOp = WebGpuSharp.StoreOp;
+using WgColor = WebGpuSharp.Color;
+using WgExtent3D = WebGpuSharp.Extent3D;
+using WgSurfaceGetCurrentTextureStatus = WebGpuSharp.SurfaceGetCurrentTextureStatus;
+
+namespace Paradise.Rendering.WebGPU;
+
+/// <summary>WebGPU (Dawn) backend entry point. Constructed with a <see cref="SurfaceDescriptor"/>
+/// for windowed rendering, or via <see cref="CreateHeadless"/> for the offscreen adapter path
+/// used by CI smoke tests. M0 exposes only the clear-color present loop; the command-stream
+/// surface (<c>BeginFrame</c>/<c>Submit</c>/<c>EndFrame</c>) lands in M1.</summary>
+public sealed class WebGpuRenderer : IDisposable
+{
+    private readonly WebGpuDevice _device;
+    private readonly SurfaceState? _surface;
+    private readonly bool _isHeadless;
+    private WgTexture? _offscreenTarget;
+    private uint _offscreenWidth;
+    private uint _offscreenHeight;
+    private bool _disposed;
+
+    /// <summary>Create a surface-backed renderer. The descriptor's platform tag selects the native
+    /// surface variant; <see cref="SurfacePlatform.Headless"/> is rejected — use
+    /// <see cref="CreateHeadless"/> instead.</summary>
+    public WebGpuRenderer(in SurfaceDescriptor surface)
+    {
+        if (surface.Platform == SurfacePlatform.Headless)
+            throw new ArgumentException(
+                "Headless platform must use WebGpuRenderer.CreateHeadless(); the surface ctor requires a real native window.",
+                nameof(surface));
+
+        var instance = WgWebGPU.CreateInstance()
+            ?? throw new InvalidOperationException("WebGPU.CreateInstance returned null — Dawn natives may be missing.");
+        var nativeSurface = SurfaceFactory.Create(instance, surface);
+        _device = WebGpuDevice.Create(instance, nativeSurface);
+        _surface = new SurfaceState(_device, nativeSurface, surface.Width, surface.Height);
+        _isHeadless = false;
+    }
+
+    private WebGpuRenderer(uint width, uint height)
+    {
+        var instance = WgWebGPU.CreateInstance()
+            ?? throw new InvalidOperationException("WebGPU.CreateInstance returned null — Dawn natives may be missing.");
+        _device = WebGpuDevice.Create(instance, compatibleSurface: null);
+        _isHeadless = true;
+        _offscreenWidth = width == 0 ? 1 : width;
+        _offscreenHeight = height == 0 ? 1 : height;
+        _offscreenTarget = CreateOffscreenTarget(_offscreenWidth, _offscreenHeight);
+    }
+
+    /// <summary>Construct the renderer using the headless adapter path. No native surface is
+    /// created; clear frames render into an offscreen <c>BGRA8Unorm</c> texture sized
+    /// <paramref name="width"/> x <paramref name="height"/>. The CI smoke test driver consumes
+    /// this path with <c>SDL_VIDEODRIVER=dummy</c>.</summary>
+    public static WebGpuRenderer CreateHeadless(uint width = 1, uint height = 1) => new(width, height);
+
+    /// <summary>Resize the surface (or offscreen target) to <paramref name="width"/> x
+    /// <paramref name="height"/>. Zero-sized requests are clamped to 1.</summary>
+    public void Resize(uint width, uint height)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_isHeadless)
+        {
+            if (width == 0) width = 1;
+            if (height == 0) height = 1;
+            if (width == _offscreenWidth && height == _offscreenHeight) return;
+            _offscreenTarget?.Destroy();
+            _offscreenWidth = width;
+            _offscreenHeight = height;
+            _offscreenTarget = CreateOffscreenTarget(width, height);
+        }
+        else
+        {
+            _surface!.Resize(width, height);
+        }
+    }
+
+    /// <summary>Acquire the next color attachment, run a single render pass that clears it to
+    /// <paramref name="clearColor"/>, submit, and present (windowed) or simply discard (headless).</summary>
+    public void RenderClearFrame(in ColorRgba clearColor)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        WgTextureView view;
+        if (_isHeadless)
+        {
+            view = _offscreenTarget!.CreateView();
+        }
+        else
+        {
+            var current = _surface!.Native.GetCurrentTexture();
+            switch (current.Status)
+            {
+                case WgSurfaceGetCurrentTextureStatus.SuccessOptimal:
+                case WgSurfaceGetCurrentTextureStatus.SuccessSuboptimal:
+                    break;
+                case WgSurfaceGetCurrentTextureStatus.Outdated:
+                case WgSurfaceGetCurrentTextureStatus.Lost:
+                    // Surface needs reconfigure (window resized between events); skip this frame.
+                    _surface.Resize(_surface.Width, _surface.Height);
+                    return;
+                default:
+                    throw new InvalidOperationException($"Surface texture acquisition failed: {current.Status}");
+            }
+            view = current.Texture!.CreateView();
+        }
+
+        var encoder = _device.Device.CreateCommandEncoder();
+
+        var colors = new WgRenderPassColorAttachment[1];
+        colors[0] = new WgRenderPassColorAttachment
+        {
+            View = view,
+            LoadOp = WgLoadOp.Clear,
+            StoreOp = WgStoreOp.Store,
+            ClearValue = new WgColor(clearColor.R, clearColor.G, clearColor.B, clearColor.A),
+            DepthSlice = null,
+        };
+
+        var passDesc = new WgRenderPassDescriptor
+        {
+            ColorAttachments = colors,
+            Label = "ParadiseClearPass",
+        };
+        var pass = encoder.BeginRenderPass(in passDesc);
+        pass.End();
+
+        var commandBuffer = encoder.Finish();
+        _device.Queue.Submit(commandBuffer);
+
+        if (!_isHeadless)
+        {
+            _surface!.Native.Present();
+        }
+    }
+
+    private WgTexture CreateOffscreenTarget(uint width, uint height)
+    {
+        var desc = new WgTextureDescriptor
+        {
+            Label = "ParadiseHeadlessTarget",
+            Size = new WgExtent3D(width, height, 1),
+            MipLevelCount = 1,
+            SampleCount = 1,
+            Dimension = WgTextureDimension.D2,
+            Format = WgTextureFormat.BGRA8Unorm,
+            Usage = WgTextureUsage.RenderAttachment | WgTextureUsage.CopySrc,
+        };
+        return _device.Device.CreateTexture(in desc);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _offscreenTarget?.Destroy();
+        _surface?.Dispose();
+        _device.Dispose();
+    }
+}

--- a/src/Paradise.Rendering.WebGPU/WebGpuRenderer.cs
+++ b/src/Paradise.Rendering.WebGPU/WebGpuRenderer.cs
@@ -116,7 +116,10 @@ public sealed class WebGpuRenderer : IDisposable
                 default:
                     throw new InvalidOperationException($"Surface texture acquisition failed: {current.Status}");
             }
-            view = current.Texture!.CreateView();
+            var surfaceTexture = current.Texture
+                ?? throw new InvalidOperationException(
+                    $"Surface texture was null despite status {current.Status} — WebGPUSharp invariant violation.");
+            view = surfaceTexture.CreateView();
         }
 
         var encoder = _device.Device.CreateCommandEncoder();

--- a/src/Paradise.Rendering.WebGPU/WebGpuRenderer.cs
+++ b/src/Paradise.Rendering.WebGPU/WebGpuRenderer.cs
@@ -108,8 +108,10 @@ public sealed class WebGpuRenderer : IDisposable
                     break;
                 case WgSurfaceGetCurrentTextureStatus.Outdated:
                 case WgSurfaceGetCurrentTextureStatus.Lost:
-                    // Surface needs reconfigure (window resized between events); skip this frame.
-                    _surface.Resize(_surface.Width, _surface.Height);
+                    // Surface needs reconfigure (window resized between events, GPU lost, etc.).
+                    // Skip this frame — caller will retry on the next tick. Force-reconfigure
+                    // even if dimensions match: the swapchain itself must be rebuilt.
+                    _surface.Reconfigure();
                     return;
                 default:
                     throw new InvalidOperationException($"Surface texture acquisition failed: {current.Status}");


### PR DESCRIPTION
Closes #41

## Summary

Stand up the WebGPU (Dawn) backend on top of the `Paradise.Rendering` data contract from #40: instance, adapter, device, queue, native surface, and a clear-color present loop. The boundary established in #40 holds — `Paradise.Rendering.WebGPU` references **only** `WebGPUSharp` and `Paradise.Rendering`, and `Paradise.Rendering.Sample` is the **only** project that references `ppy.SDL3-CS`.

### Public surface (`Paradise.Rendering.WebGPU`)

- `WebGpuRenderer` — surface-backed ctor (`WebGpuRenderer(in SurfaceDescriptor)`) and `CreateHeadless(width, height)` static, plus `Resize(uint, uint)`, `RenderClearFrame(in ColorRgba)`, `Dispose()`. Headless is rejected on the surface ctor with a clear `ArgumentException`; the static factory is the only path.

### Internal state

- `WebGpuDevice` — owns `Instance` / `Adapter` / `Device` / `Queue`. Adapter request takes either a compatible surface or null (headless). `RequestAdapterSync` / `RequestDeviceSync` with 10s timeout.
- `SurfaceState` — owns the configured surface, picks `caps.Formats[0]` (or BGRA8Unorm fallback), reconfigures on `Resize`, unconfigures on dispose.
- `SurfaceFactory` — OS-dispatches on `SurfacePlatform`: Win32→`SurfaceSourceWindowsHWNDFFI`, Xlib→`SurfaceSourceXlibWindowFFI`, Wayland→`SurfaceSourceWaylandSurfaceFFI`, Cocoa→`SurfaceSourceMetalLayerFFI`. Headless is rejected here too.
- `SlotTable<T>` — generation-tracked slot allocator (free-list backed). Generation 0 is reserved for the invalid sentinel matching the public handle structs. Scaffold for M1 resource slots.

### Sample (`Paradise.Rendering.Sample`)

- `net10.0`, `<PublishAot>true</PublishAot>` (matches BT.Sample / ECS.Sample). Default mode: SDL3 windowed, resizable, presents `ColorRgba.CornflowerBlue` clear frames. `--headless N` mode: sets `SDL_HINT_VIDEO_DRIVER=dummy` via `SDL_SetHint` (managed `Environment.SetEnvironmentVariable` doesn't reliably reach SDL's libc `getenv` cache), constructs `WebGpuRenderer.CreateHeadless(...)`, runs N clear frames against an offscreen target, exits 0.
- OS-conditional surface mapping in the sample only — Win32 reads HWND, macOS reads NSWindow*, Linux reads Wayland display+surface (preferred) or X11 display+window. Cocoa support is documented as a known constraint per the issue spec; full CAMetalLayer wrap-up is deferred until M0b runs on macOS.

### Packages added

- `WebGPUSharp 0.5.2` — Dawn natives shipped in-package for win/osx/linux x64+arm64. `[DisableRuntimeMarshalling]`, no reflection.
- `ppy.SDL3-CS 2026.320.0` — pure P/Invoke, AOT-clean, native SDL3 per RID (also covers ios/android/win-x86).

Both versions live in `src/Directory.Packages.props`. The sample project is the only consumer of `ppy.SDL3-CS`; `Paradise.Rendering.WebGPU` does not depend on it.

## Test plan

- [x] Solution builds with `dotnet build ParadiseEngine.slnx -p:TreatWarningsAsErrors=true` — 0 errors.
- [x] Full test suite: `dotnet test --solution ParadiseEngine.slnx -p:PublishAot=false --output normal` — **1953 passed, 0 failed, 0 skipped**. Four new tests in `Paradise.Rendering.WebGPU.Test` exercise the headless adapter path.
- [x] AOT publish: `dotnet publish src/Paradise.Rendering.Sample -c Release` — clean, no trim/AOT warnings on `linux-x64`. Other RIDs (`win-x64`, `osx-arm64`) covered by the published WebGPUSharp + ppy.SDL3-CS native bundles.
- [x] AOT smoke: `./Paradise.Rendering.Sample --headless 5` from the publish output prints `Headless mode: rendered 5 clear frames against an offscreen target.` and exits 0.
- [x] Public surface check: zero `IRenderDevice` / `IBuffer` / `ITexture` interfaces; only handles + descriptors + `WebGpuRenderer`.
- [x] Boundary check: `Paradise.Rendering.WebGPU` references only `WebGPUSharp` + `Paradise.Rendering`; `Paradise.Rendering.Sample` is the only project referencing `ppy.SDL3-CS`.

## Notes

- **`SDL_SetHint` vs `Environment.SetEnvironmentVariable`** — headless dummy-driver mode uses SDL's hint API (`SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "dummy")`) rather than writing the process env var. Managed `Environment.SetEnvironmentVariable` does **not** reliably reach SDL's video subsystem because libc `getenv` may have cached at process start — once SDL's `SDL_Init` calls `getenv("SDL_VIDEODRIVER")` it can see stale/absent data even after the managed write. Please do **not** suggest reverting to `Environment.SetEnvironmentVariable`; the SDL hint API is the correct path. There's an in-line comment in `Program.cs` at the call site with the same rationale.
- **Headless adapter coverage** — the 1953-test run covers this PR on a Linux host with `mesa-vulkan-drivers` + `libvulkan1` (lavapipe → Dawn Vulkan adapter). On hosts without any Vulkan/Metal/DX12 adapter, the four smoke tests skip cleanly via `Skip.Test(...)` rather than failing; the AOT publish itself is the load-bearing M0 acceptance signal per the issue spec.
- **AOT publish** — verified on `linux-x64` from this branch; `win-x64` / `osx-arm64` / `osx-x64` / `win-arm64` / `linux-arm64` are covered by the published WebGPUSharp + ppy.SDL3-CS native bundles but not run end-to-end here. CI covers the other RIDs when the pipeline exists.
- **Pre-existing build noise** — `NETSDK1188 locale is not recognized` warnings (`cs`, `de`, `es`, `pt-br`, `zh-hans`, etc.) come from `Microsoft.Testing.Platform 2.0.2` / `Microsoft.Testing.Platform.MSBuild 2.0.2`'s packaging and were present before this PR. Not introduced or modifiable from this repo — upstream issue.
- **macOS Cocoa constraint** — the sample passes the SDL3-exposed `NSWindow*` rather than a `CAMetalLayer*`. Full CAMetalLayer wrap-up (creation on the main thread + attachment to `NSWindow.contentView.layer`) is deferred until M0b is exercised on macOS hardware. Documented in the issue spec; not a blocker for the headless acceptance path.
