### PR TITLE
ci: add AOT publish-and-run job for Paradise.BT.Sample

### DIFF
--- a/.github/workflows/aot-sample.yml
+++ b/.github/workflows/aot-sample.yml
@@ -1,0 +1,36 @@
+name: AOT Sample
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  aot-publish-run:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install NativeAOT prerequisites
+        run: sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish Paradise.BT.Sample (NativeAOT)
+        run: >
+          dotnet publish src/Paradise.BT.Sample/Paradise.BT.Sample.csproj
+          -c Release
+          -r linux-x64
+          -p:TreatWarningsAsErrors=true
+
+      - name: Run native binary
+        run: src/Paradise.BT.Sample/bin/Release/net10.0/linux-x64/publish/Paradise.BT.Sample


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/aot-sample.yml`, a dedicated CI workflow that publishes `Paradise.BT.Sample` under NativeAOT (`-r linux-x64`) and executes the resulting native binary.
- The job runs **in parallel** with the existing test job (separate workflow) so PR feedback time is not impacted.
- Uses `actions/setup-dotnet@v4` with `global-json-file: global.json` for SDK consistency.
- Passes `-p:TreatWarningsAsErrors=true` so any AOT/trimming warnings fail the build.
- Installs `clang` and `zlib1g-dev` — required NativeAOT prerequisites on Ubuntu runners.

Closes #36

## Test plan

- [ ] Verify the `AOT Sample` workflow appears on this PR in GitHub Actions.
- [ ] Confirm the publish step shows ILCompiler output in the logs.
- [ ] Confirm the binary execution step exits with code 0 (all 10 ticks logged, no crash).
- [ ] Verify the existing `.NET Test` workflow is unchanged and still passes.