### PR TITLE
[dev] Renderer M3: ECS extraction layer (extract systems → frame packets)

### DIFF
--- a/ParadiseEngine.slnx
+++ b/ParadiseEngine.slnx
@@ -21,6 +21,7 @@
     <Project Path="src/Paradise.ECS.Tag/Paradise.ECS.Tag.csproj" />
     <Project Path="src/Paradise.ECS/Paradise.ECS.csproj" />
     <Project Path="src/Paradise.Rendering/Paradise.Rendering.csproj" />
+    <Project Path="src/Paradise.Rendering.ECS/Paradise.Rendering.ECS.csproj" />
     <Project Path="src/Paradise.Rendering.WebGPU/Paradise.Rendering.WebGPU.csproj" />
   </Folder>
   <Folder Name="/tests/">
@@ -32,6 +33,7 @@
     <Project Path="src/Paradise.ECS.Jobs.Test/Paradise.ECS.Jobs.Test.csproj" />
     <Project Path="src/Paradise.ECS.Generators.Test/Paradise.ECS.Generators.Test.csproj" />
     <Project Path="src/Paradise.ECS.Test/Paradise.ECS.Test.csproj" />
+    <Project Path="src/Paradise.Rendering.ECS.Test/Paradise.Rendering.ECS.Test.csproj" />
     <Project Path="src/Paradise.Rendering.Test/Paradise.Rendering.Test.csproj" />
     <Project Path="src/Paradise.Rendering.WebGPU.Test/Paradise.Rendering.WebGPU.Test.csproj" />
   </Folder>

--- a/src/Paradise.Rendering.ECS.Test/ExtractionTests.cs
+++ b/src/Paradise.Rendering.ECS.Test/ExtractionTests.cs
@@ -1,0 +1,241 @@
+using System.Numerics;
+
+namespace Paradise.Rendering.ECS.Test;
+
+/// <summary>Integration tests for the ECS extraction pipeline.</summary>
+public sealed class ExtractionTests : IDisposable
+{
+    private readonly SharedWorld<SmallBitSet<uint>, DefaultConfig> _sharedWorld;
+    private readonly World<SmallBitSet<uint>, DefaultConfig> _world;
+    private readonly FrameRenderPackets _packets;
+    private readonly SystemSchedule<SmallBitSet<uint>, DefaultConfig> _extractSchedule;
+
+    public ExtractionTests()
+    {
+        _sharedWorld = SharedWorldFactory.Create();
+        _world = _sharedWorld.CreateWorld();
+        _packets = new FrameRenderPackets();
+        _extractSchedule = SystemSchedule.Create(_world)
+            .Add<ExtractRenderablesSystem>()
+            .Add<ExtractCamerasSystem>()
+            .Build<SequentialWaveScheduler>();
+    }
+
+    public void Dispose()
+    {
+        _extractSchedule.Dispose();
+        _sharedWorld.Dispose();
+    }
+
+    private void RunExtraction()
+    {
+        ExtractionContext.Packets = _packets;
+        _packets.Reset();
+        _extractSchedule.Run();
+        ExtractionContext.Packets = null;
+    }
+
+    // ---- Renderable extraction ----
+
+    [Test]
+    public async Task Extraction_KnownPopulation_ProducesExactRenderableCount()
+    {
+        const int count = 50;
+        for (int i = 0; i < count; i++)
+        {
+            var e = _world.Spawn();
+            _world.AddComponent(e, new LocalToWorld { Value = Matrix4x4.Identity });
+            _world.AddComponent(e, new MeshRef { MeshId = (uint)i });
+            _world.AddComponent(e, new MaterialRef { MaterialId = 1 });
+        }
+
+        RunExtraction();
+
+        await Assert.That(_packets.Renderables.Length).IsEqualTo(count);
+    }
+
+    [Test]
+    public async Task Extraction_EntityMissingComponent_NotExtracted()
+    {
+        // Entity with only LocalToWorld + MeshRef — no MaterialRef → should NOT be extracted.
+        var incomplete = _world.Spawn();
+        _world.AddComponent(incomplete, new LocalToWorld { Value = Matrix4x4.Identity });
+        _world.AddComponent(incomplete, new MeshRef { MeshId = 99 });
+
+        // Entity with all three components → should be extracted.
+        var complete = _world.Spawn();
+        _world.AddComponent(complete, new LocalToWorld { Value = Matrix4x4.Identity });
+        _world.AddComponent(complete, new MeshRef { MeshId = 1 });
+        _world.AddComponent(complete, new MaterialRef { MaterialId = 1 });
+
+        RunExtraction();
+
+        await Assert.That(_packets.Renderables.Length).IsEqualTo(1);
+        await Assert.That(_packets.Renderables.Span[0].MeshId).IsEqualTo(1u);
+    }
+
+    [Test]
+    public async Task Extraction_Transform_RoundTrips()
+    {
+        var transform = new Matrix4x4(
+            1, 2, 3, 4,
+            5, 6, 7, 8,
+            9, 10, 11, 12,
+            13, 14, 15, 16);
+
+        var e = _world.Spawn();
+        _world.AddComponent(e, new LocalToWorld { Value = transform });
+        _world.AddComponent(e, new MeshRef { MeshId = 7 });
+        _world.AddComponent(e, new MaterialRef { MaterialId = 3 });
+
+        RunExtraction();
+
+        await Assert.That(_packets.Renderables.Length).IsEqualTo(1);
+        var r = _packets.Renderables.Span[0];
+        await Assert.That(r.LocalToWorld).IsEqualTo(transform);
+        await Assert.That(r.MeshId).IsEqualTo(7u);
+        await Assert.That(r.MaterialId).IsEqualTo(3u);
+    }
+
+    // ---- Camera extraction ----
+
+    [Test]
+    public async Task Extraction_KnownPopulation_ProducesExactCameraCount()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            var e = _world.Spawn();
+            _world.AddComponent(e, new CameraComponent
+            {
+                View = Matrix4x4.Identity,
+                Projection = Matrix4x4.Identity,
+                TargetView = uint.MaxValue,
+            });
+        }
+
+        RunExtraction();
+
+        await Assert.That(_packets.Cameras.Length).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Extraction_Camera_ViewProjectionRoundTrip()
+    {
+        // Use a simple asymmetric view and projection so the product is unique.
+        var view = Matrix4x4.CreateLookAt(
+            new Vector3(0, 0, 5),
+            Vector3.Zero,
+            Vector3.UnitY);
+        var proj = Matrix4x4.CreateOrthographic(2f, 2f, 0.1f, 100f);
+        var expected = view * proj;
+
+        var e = _world.Spawn();
+        _world.AddComponent(e, new CameraComponent
+        {
+            View = view,
+            Projection = proj,
+            TargetView = uint.MaxValue,
+        });
+
+        RunExtraction();
+
+        await Assert.That(_packets.Cameras.Length).IsEqualTo(1);
+        var cam = _packets.Cameras.Span[0];
+        // Compare element-by-element to avoid floating-point noise in equality override.
+        await Assert.That(cam.ViewProjection.M11).IsEqualTo(expected.M11);
+        await Assert.That(cam.ViewProjection.M44).IsEqualTo(expected.M44);
+    }
+
+    [Test]
+    public async Task Extraction_Camera_SwapchainTarget_ProducesInvalidHandle()
+    {
+        var e = _world.Spawn();
+        _world.AddComponent(e, new CameraComponent
+        {
+            View = Matrix4x4.Identity,
+            Projection = Matrix4x4.Identity,
+            TargetView = uint.MaxValue,
+        });
+
+        RunExtraction();
+
+        await Assert.That(_packets.Cameras.Span[0].TargetView).IsEqualTo(RenderViewHandle.Invalid);
+    }
+
+    [Test]
+    public async Task Extraction_Camera_ExplicitTarget_ProducesValidHandle()
+    {
+        var e = _world.Spawn();
+        _world.AddComponent(e, new CameraComponent
+        {
+            View = Matrix4x4.Identity,
+            Projection = Matrix4x4.Identity,
+            TargetView = 2u,
+        });
+
+        RunExtraction();
+
+        var handle = _packets.Cameras.Span[0].TargetView;
+        await Assert.That(handle.IsValid).IsTrue();
+        await Assert.That(handle.Index).IsEqualTo(2u);
+    }
+
+    // ---- Allocation-free steady state ----
+
+    [Test]
+    public async Task Extraction_SteadyState_ProducesNoGcAllocations()
+    {
+        // Populate the world with a realistic scene: 100 renderables + 1 camera.
+        for (int i = 0; i < 100; i++)
+        {
+            var e = _world.Spawn();
+            _world.AddComponent(e, new LocalToWorld { Value = Matrix4x4.Identity });
+            _world.AddComponent(e, new MeshRef { MeshId = (uint)(i % 4) });
+            _world.AddComponent(e, new MaterialRef { MaterialId = (uint)(i % 2) });
+        }
+        var camEntity = _world.Spawn();
+        _world.AddComponent(camEntity, new CameraComponent
+        {
+            View = Matrix4x4.Identity,
+            Projection = Matrix4x4.CreateOrthographic(2f, 2f, 0.1f, 100f),
+            TargetView = uint.MaxValue,
+        });
+
+        // Warm-up: let internal lists/buffers reach steady-state capacity.
+        for (int i = 0; i < 10; i++)
+            RunExtraction();
+
+        // Measure allocation over 100 frames.
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 100; i++)
+            RunExtraction();
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        // Allow a small budget for framework internals (ECB playback, scheduler dispatch).
+        // Observed steady-state is ~64 bytes/frame from fixed-cost overhead unrelated to renderable count.
+        // 8 KB covers 80 bytes/frame × 100 frames; still catches any per-renderable regression
+        // (100 renderables × even 1 byte each = 10 KB, which would exceed this threshold).
+        const long thresholdBytes = 8 * 1024; // 8 KB
+        await Assert.That(after - before).IsLessThanOrEqualTo(thresholdBytes);
+    }
+
+    // ---- Multi-frame consistency ----
+
+    [Test]
+    public async Task Extraction_MultipleFrames_ProducesConsistentResults()
+    {
+        var e = _world.Spawn();
+        _world.AddComponent(e, new LocalToWorld { Value = Matrix4x4.Identity });
+        _world.AddComponent(e, new MeshRef { MeshId = 42 });
+        _world.AddComponent(e, new MaterialRef { MaterialId = 7 });
+
+        RunExtraction();
+        int firstCount = _packets.Renderables.Length;
+
+        RunExtraction();
+        int secondCount = _packets.Renderables.Length;
+
+        await Assert.That(firstCount).IsEqualTo(secondCount);
+        await Assert.That(firstCount).IsEqualTo(1);
+    }
+}

--- a/src/Paradise.Rendering.ECS.Test/Paradise.Rendering.ECS.Test.csproj
+++ b/src/Paradise.Rendering.ECS.Test/Paradise.Rendering.ECS.Test.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Paradise.ECS.Common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <!-- CA1515: public test classes needed for TUnit discovery -->
+    <!-- CA1707: allow underscore in test method names -->
+    <NoWarn>$(NoWarn);CA1515;CA1707</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paradise.Rendering.ECS\Paradise.Rendering.ECS.csproj" />
+    <ProjectReference Include="..\Paradise.ECS\Paradise.ECS.csproj" />
+    <ProjectReference Include="..\Paradise.ECS.Generators\Paradise.ECS.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Paradise.ECS" />
+    <Using Include="Paradise.Rendering.ECS" />
+    <Using Include="Paradise.Rendering.ECS.Systems" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paradise.Rendering.ECS/Components.cs
+++ b/src/Paradise.Rendering.ECS/Components.cs
@@ -1,0 +1,57 @@
+using System.Numerics;
+using Paradise.ECS;
+
+namespace Paradise.Rendering.ECS;
+
+/// <summary>World-space transform matrix for a renderable entity.</summary>
+[Component]
+public partial struct LocalToWorld
+{
+    public Matrix4x4 Value;
+}
+
+/// <summary>Application-defined mesh identifier. Mapped to a GPU vertex buffer at submission time.</summary>
+[Component]
+public partial struct MeshRef
+{
+    public uint MeshId;
+}
+
+/// <summary>Application-defined material identifier. Mapped to a pipeline/bind-group at submission time.</summary>
+[Component]
+public partial struct MaterialRef
+{
+    public uint MaterialId;
+}
+
+/// <summary>
+/// Camera parameters read by the extraction system to produce a <see cref="ExtractedCamera"/>.
+/// <para>
+/// <see cref="View"/> and <see cref="Projection"/> are combined into a single ViewProjection matrix
+/// during extraction so the renderer never touches live ECS state during submission.
+/// </para>
+/// </summary>
+[Component]
+public partial struct CameraComponent
+{
+    public Matrix4x4 View;
+    public Matrix4x4 Projection;
+
+    /// <summary>
+    /// Index into the application's render-view table, or <c>uint.MaxValue</c> (i.e., -1 cast to uint)
+    /// to target the swapchain surface.
+    /// </summary>
+    public uint TargetView;
+}
+
+/// <summary>Query descriptor: entities that can be rendered (have transform + mesh + material).</summary>
+[Queryable]
+[With<LocalToWorld>(IsReadOnly = true)]
+[With<MeshRef>(IsReadOnly = true)]
+[With<MaterialRef>(IsReadOnly = true)]
+public readonly ref partial struct RenderableQuery;
+
+/// <summary>Query descriptor: entities that act as cameras.</summary>
+[Queryable]
+[With<CameraComponent>(IsReadOnly = true)]
+public readonly ref partial struct CameraQuery;

--- a/src/Paradise.Rendering.ECS/ExtractedPackets.cs
+++ b/src/Paradise.Rendering.ECS/ExtractedPackets.cs
@@ -1,0 +1,117 @@
+using System.Buffers;
+using System.Numerics;
+
+namespace Paradise.Rendering.ECS;
+
+/// <summary>
+/// A single extracted renderable: fully resolved, renderer-facing data for one draw call.
+/// Frame-local; rebuilt every frame from ECS state by <see cref="Systems.ExtractRenderablesSystem"/>.
+/// </summary>
+public readonly struct ExtractedRenderable
+{
+    public Matrix4x4 LocalToWorld { get; init; }
+    public uint MeshId { get; init; }
+    public uint MaterialId { get; init; }
+}
+
+/// <summary>
+/// A single extracted camera: view-projection matrix and optional render-view override.
+/// Frame-local; rebuilt every frame from ECS state by <see cref="Systems.ExtractCamerasSystem"/>.
+/// </summary>
+public readonly struct ExtractedCamera
+{
+    /// <summary>View * Projection, pre-multiplied at extract time.</summary>
+    public Matrix4x4 ViewProjection { get; init; }
+
+    /// <summary>
+    /// Resolved render-view handle. <see cref="RenderViewHandle.Invalid"/> targets the swapchain.
+    /// </summary>
+    public RenderViewHandle TargetView { get; init; }
+}
+
+/// <summary>
+/// Frame-local container for all extracted rendering data.
+/// Uses <see cref="ArrayPool{T}"/> buffers so steady-state operation produces zero GC pressure.
+/// Call <see cref="Reset"/> at the start of each frame before running the extraction stage.
+/// </summary>
+public sealed class FrameRenderPackets
+{
+    private ExtractedRenderable[] _renderablesBuffer;
+    private ExtractedCamera[] _camerasBuffer;
+    private int _renderableCount;
+    private int _cameraCount;
+
+    public FrameRenderPackets()
+    {
+        _renderablesBuffer = ArrayPool<ExtractedRenderable>.Shared.Rent(64);
+        _camerasBuffer = ArrayPool<ExtractedCamera>.Shared.Rent(8);
+    }
+
+    /// <summary>All renderables accumulated this frame.</summary>
+    public ReadOnlyMemory<ExtractedRenderable> Renderables => _renderablesBuffer.AsMemory(0, _renderableCount);
+
+    /// <summary>All cameras accumulated this frame.</summary>
+    public ReadOnlyMemory<ExtractedCamera> Cameras => _camerasBuffer.AsMemory(0, _cameraCount);
+
+    /// <summary>
+    /// Clears packet counts so this frame's extraction can repopulate the buffers.
+    /// Does not release or reallocate backing arrays — zero GC pressure.
+    /// </summary>
+    public void Reset()
+    {
+        _renderableCount = 0;
+        _cameraCount = 0;
+    }
+
+    /// <summary>Appends one renderable. Called by <see cref="Systems.ExtractRenderablesSystem"/>.</summary>
+    internal void AppendRenderable(in ExtractedRenderable r)
+    {
+        if (_renderableCount == _renderablesBuffer.Length)
+            GrowRenderables();
+        _renderablesBuffer[_renderableCount++] = r;
+    }
+
+    /// <summary>Appends one camera. Called by <see cref="Systems.ExtractCamerasSystem"/>.</summary>
+    internal void AppendCamera(in ExtractedCamera c)
+    {
+        if (_cameraCount == _camerasBuffer.Length)
+            GrowCameras();
+        _camerasBuffer[_cameraCount++] = c;
+    }
+
+    private void GrowRenderables()
+    {
+        var next = ArrayPool<ExtractedRenderable>.Shared.Rent(_renderablesBuffer.Length * 2);
+        _renderablesBuffer.AsSpan(0, _renderableCount).CopyTo(next);
+        ArrayPool<ExtractedRenderable>.Shared.Return(_renderablesBuffer);
+        _renderablesBuffer = next;
+    }
+
+    private void GrowCameras()
+    {
+        var next = ArrayPool<ExtractedCamera>.Shared.Rent(_camerasBuffer.Length * 2);
+        _camerasBuffer.AsSpan(0, _cameraCount).CopyTo(next);
+        ArrayPool<ExtractedCamera>.Shared.Return(_camerasBuffer);
+        _camerasBuffer = next;
+    }
+}
+
+/// <summary>
+/// Thread-local context that extraction systems use to locate the current frame's packet buffer.
+/// Set <see cref="Packets"/> before running the extraction schedule; leave it as <c>null</c> when idle.
+/// </summary>
+public static class ExtractionContext
+{
+    [ThreadStatic]
+    private static FrameRenderPackets? s_packets;
+
+    /// <summary>
+    /// The packet buffer being populated by the current extraction pass.
+    /// <c>null</c> outside an active extraction pass.
+    /// </summary>
+    public static FrameRenderPackets? Packets
+    {
+        get => s_packets;
+        set => s_packets = value;
+    }
+}

--- a/src/Paradise.Rendering.ECS/Paradise.Rendering.ECS.csproj
+++ b/src/Paradise.Rendering.ECS/Paradise.Rendering.ECS.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Paradise.ECS.Common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
+    <!-- CA1515: internal class warning suppressed — bridge library exposes types intentionally public -->
+    <NoWarn>$(NoWarn);CA1515</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Paradise.Rendering\Paradise.Rendering.csproj" />
+    <ProjectReference Include="..\Paradise.ECS\Paradise.ECS.csproj" />
+    <ProjectReference Include="..\Paradise.ECS.Generators\Paradise.ECS.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Paradise.Rendering.ECS/Systems/ExtractCamerasSystem.cs
+++ b/src/Paradise.Rendering.ECS/Systems/ExtractCamerasSystem.cs
@@ -1,0 +1,38 @@
+using Paradise.ECS;
+
+namespace Paradise.Rendering.ECS.Systems;
+
+/// <summary>
+/// ECS chunk system that reads <see cref="CameraComponent"/> from every matching chunk and
+/// appends one <see cref="ExtractedCamera"/> per entity to the current frame's
+/// <see cref="ExtractionContext.Packets"/>.
+/// <para>
+/// The View and Projection matrices are multiplied at extract time so the renderer receives a
+/// single ready-to-use ViewProjection matrix — the live ECS world is never accessed after
+/// the extraction pass completes.
+/// </para>
+/// </summary>
+public ref partial struct ExtractCamerasSystem : IChunkSystem
+{
+    public ReadOnlySpan<CameraComponent> CameraComponents;
+
+    public void ExecuteChunk()
+    {
+        var packets = ExtractionContext.Packets!;
+        for (int i = 0; i < CameraComponents.Length; i++)
+        {
+            ref readonly var cam = ref CameraComponents[i];
+
+            // Resolve the render-view target: uint.MaxValue (-1) means swapchain surface.
+            var targetView = cam.TargetView == uint.MaxValue
+                ? RenderViewHandle.Invalid
+                : new RenderViewHandle(cam.TargetView, 1u);
+
+            packets.AppendCamera(new ExtractedCamera
+            {
+                ViewProjection = cam.View * cam.Projection,
+                TargetView = targetView,
+            });
+        }
+    }
+}

--- a/src/Paradise.Rendering.ECS/Systems/ExtractRenderablesSystem.cs
+++ b/src/Paradise.Rendering.ECS/Systems/ExtractRenderablesSystem.cs
@@ -1,0 +1,39 @@
+using Paradise.ECS;
+
+namespace Paradise.Rendering.ECS.Systems;
+
+/// <summary>
+/// ECS chunk system that reads <see cref="LocalToWorld"/>, <see cref="MeshRef"/>, and
+/// <see cref="MaterialRef"/> from every matching chunk and appends one
+/// <see cref="ExtractedRenderable"/> per entity to the current frame's
+/// <see cref="ExtractionContext.Packets"/>.
+/// <para>
+/// Wire this into the extraction <see cref="SystemSchedule{TMask,TConfig}"/> and set
+/// <see cref="ExtractionContext.Packets"/> before calling <c>Run()</c>:
+/// <code>
+/// ExtractionContext.Packets = packets;
+/// packets.Reset();
+/// extractSchedule.Run();
+/// </code>
+/// </para>
+/// </summary>
+public ref partial struct ExtractRenderablesSystem : IChunkSystem
+{
+    public ReadOnlySpan<LocalToWorld> LocalToWorlds;
+    public ReadOnlySpan<MeshRef> MeshRefs;
+    public ReadOnlySpan<MaterialRef> MaterialRefs;
+
+    public void ExecuteChunk()
+    {
+        var packets = ExtractionContext.Packets!;
+        for (int i = 0; i < LocalToWorlds.Length; i++)
+        {
+            packets.AppendRenderable(new ExtractedRenderable
+            {
+                LocalToWorld = LocalToWorlds[i].Value,
+                MeshId = MeshRefs[i].MeshId,
+                MaterialId = MaterialRefs[i].MaterialId,
+            });
+        }
+    }
+}

--- a/src/Paradise.Rendering.Sample/EcsScene.cs
+++ b/src/Paradise.Rendering.Sample/EcsScene.cs
@@ -1,0 +1,70 @@
+using System.Numerics;
+using Paradise.ECS;
+using Paradise.Rendering.ECS;
+using Paradise.Rendering.ECS.Systems;
+
+namespace Paradise.Rendering.Sample;
+
+/// <summary>
+/// Owns an ECS world populated with 100 renderable quad stand-ins and one camera, and drives the
+/// extraction schedule each frame to populate a <see cref="FrameRenderPackets"/> buffer.
+/// Demonstrates the M3 ECS-to-renderer extraction bridge.
+/// </summary>
+internal sealed class EcsScene : IDisposable
+{
+    private readonly SharedWorld<SmallBitSet<uint>, DefaultConfig> _sharedWorld;
+    private readonly World<SmallBitSet<uint>, DefaultConfig> _world;
+    private readonly FrameRenderPackets _packets;
+    private readonly SystemSchedule<SmallBitSet<uint>, DefaultConfig> _schedule;
+
+    public FrameRenderPackets Packets => _packets;
+
+    public EcsScene()
+    {
+        _sharedWorld = SharedWorldFactory.Create();
+        _world = _sharedWorld.CreateWorld();
+        _packets = new FrameRenderPackets();
+
+        // Spawn 100 renderable entities (placeholder mesh 0, material 0).
+        for (int i = 0; i < 100; i++)
+        {
+            var e = _world.Spawn();
+            _world.AddComponent(e, new LocalToWorld { Value = Matrix4x4.CreateTranslation(i, 0, 0) });
+            _world.AddComponent(e, new MeshRef { MeshId = 0u });
+            _world.AddComponent(e, new MaterialRef { MaterialId = 0u });
+        }
+
+        // Spawn one camera targeting the swapchain.
+        var cam = _world.Spawn();
+        _world.AddComponent(cam, new CameraComponent
+        {
+            View = Matrix4x4.CreateLookAt(new Vector3(0, 0, 50), Vector3.Zero, Vector3.UnitY),
+            Projection = Matrix4x4.CreateOrthographic(100f, 75f, 0.1f, 200f),
+            TargetView = uint.MaxValue,
+        });
+
+        _schedule = SystemSchedule.Create(_world)
+            .Add<ExtractRenderablesSystem>()
+            .Add<ExtractCamerasSystem>()
+            .Build<SequentialWaveScheduler>();
+    }
+
+    /// <summary>
+    /// Runs the extraction schedule for the current frame.
+    /// Returns the number of renderables and cameras extracted.
+    /// </summary>
+    public (int Renderables, int Cameras) Extract()
+    {
+        ExtractionContext.Packets = _packets;
+        _packets.Reset();
+        _schedule.Run();
+        ExtractionContext.Packets = null;
+        return (_packets.Renderables.Length, _packets.Cameras.Length);
+    }
+
+    public void Dispose()
+    {
+        _schedule.Dispose();
+        _sharedWorld.Dispose();
+    }
+}

--- a/src/Paradise.Rendering.Sample/Paradise.Rendering.Sample.csproj
+++ b/src/Paradise.Rendering.Sample/Paradise.Rendering.Sample.csproj
@@ -10,7 +10,10 @@
 
   <ItemGroup>
     <ProjectReference Include="../Paradise.Rendering/Paradise.Rendering.csproj" />
+    <ProjectReference Include="../Paradise.Rendering.ECS/Paradise.Rendering.ECS.csproj" />
     <ProjectReference Include="../Paradise.Rendering.WebGPU/Paradise.Rendering.WebGPU.csproj" />
+    <ProjectReference Include="../Paradise.ECS/Paradise.ECS.csproj" />
+    <ProjectReference Include="../Paradise.ECS.Generators/Paradise.ECS.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Paradise.Rendering.Sample/Program.cs
+++ b/src/Paradise.Rendering.Sample/Program.cs
@@ -62,9 +62,18 @@ internal static class Program
         {
             using var renderer = WebGpuRenderer.CreateHeadless(InitialWidth, InitialHeight);
             using var scene = new TriangleScene(renderer);
+            using var ecs = new EcsScene();
+
             for (var i = 0; i < frameCount; i++)
+            {
+                var (renderables, cameras) = ecs.Extract();
                 scene.RenderFrame();
-            Console.WriteLine($"Headless mode: rendered {frameCount} triangle frames against an offscreen target.");
+
+                if (i == 0)
+                    Console.WriteLine($"ECS extraction (frame 0): {renderables} renderables, {cameras} cameras.");
+            }
+
+            Console.WriteLine($"Headless mode: rendered {frameCount} triangle frame(s) with ECS extraction active.");
             return 0;
         }
         finally


### PR DESCRIPTION
## Summary

- Add `Paradise.Rendering.ECS` project with ECS components (`LocalToWorld`, `MeshRef`, `MaterialRef`, `CameraComponent`), queryables (`RenderableQuery`, `CameraQuery`), frame packet types (`FrameRenderPackets`, `ExtractedRenderable`, `ExtractedCamera`), and extraction chunk systems (`ExtractRenderablesSystem`, `ExtractCamerasSystem`)
- Add `Paradise.Rendering.ECS.Test` with 9 integration tests covering extraction count, transform round-trip, camera ViewProjection, render-view handle mapping, steady-state allocation, and multi-frame consistency
- Wire ECS extraction into `Paradise.Rendering.Sample` via `EcsScene` (100 renderable entities + 1 camera); headless mode runs extraction each frame alongside existing triangle rendering

## Test plan

- [x] `dotnet build -p:TreatWarningsAsErrors=true` — 0 errors across full solution
- [x] `dotnet run --project src/Paradise.Rendering.ECS.Test/` — 9/9 tests pass
- [x] `dotnet run --project src/Paradise.Rendering.Sample/ -- --headless 10` — prints `ECS extraction (frame 0): 100 renderables, 1 cameras.`

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)